### PR TITLE
fix: accept integer 0 as valid arg input

### DIFF
--- a/src/parser/validate.ts
+++ b/src/parser/validate.ts
@@ -34,7 +34,7 @@ export function validate(parse: {
       }
 
       if (arg.required) {
-        if (!parse.output.argv[index]) {
+        if (!parse.output.argv[index] && parse.output.argv[index] as any as number !== 0) {
           missingRequiredArgs.push(arg)
         }
       }

--- a/test/parser/validate.test.ts
+++ b/test/parser/validate.test.ts
@@ -89,15 +89,20 @@ describe('validate', () => {
           required: true,
         },
       },
-      args: [],
+      args: [
+        {
+          name: 'zero',
+          required: true,
+        },
+      ],
       strict: true,
       context: {},
       '--': true,
     }
 
     const output = {
-      args: {},
-      argv: [],
+      args: {zero: 0},
+      argv: [0],
       flags: {int: 0},
       raw: [],
       metadata: {


### PR DESCRIPTION
From: https://github.com/oclif/parser/commit/2619871f2e9c669863f32a73fa00b49d4e18d333