### PR TITLE
fix: don't resolve lib -> src in development mode

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -26,15 +26,6 @@ function channelFromVersion(version: string) {
   return (m && m[1]) || 'stable'
 }
 
-function hasManifest(p: string): boolean {
-  try {
-    require(p)
-    return true
-  } catch {
-    return false
-  }
-}
-
 const WSL = require('is-wsl')
 
 function isConfig(o: any): o is IConfig {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -181,9 +181,8 @@ export class Config implements IConfig {
   }
 
   async loadDevPlugins() {
-    if (this.options.devPlugins !== false) {
-      // do not load oclif.devPlugins in production
-      if (hasManifest(path.join(this.root, 'oclif.manifest.json'))) return
+    // do not load oclif.devPlugins in production
+    if (this.options.devPlugins !== false && process.env.NODE_ENV === 'development') {
       try {
         const devPlugins = this.pjson.oclif.devPlugins
         if (devPlugins) await this.loadPlugins(this.root, 'dev', devPlugins)

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -461,7 +461,7 @@ export class Config implements IConfig {
   }
 
   protected get isProd() {
-    return process.env.NODE_DEV !== 'development'
+    return process.env.NODE_ENV !== 'development'
   }
 }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -173,13 +173,12 @@ export class Config implements IConfig {
 
   async loadDevPlugins() {
     // do not load oclif.devPlugins in production
-    if (this.options.devPlugins !== false && process.env.NODE_ENV === 'development') {
-      try {
-        const devPlugins = this.pjson.oclif.devPlugins
-        if (devPlugins) await this.loadPlugins(this.root, 'dev', devPlugins)
-      } catch (error) {
-        process.emitWarning(error)
-      }
+    if (this.isProd) return
+    try {
+      const devPlugins = this.pjson.oclif.devPlugins
+      if (devPlugins) await this.loadPlugins(this.root, 'dev', devPlugins)
+    } catch (error) {
+      process.emitWarning(error)
     }
   }
 
@@ -459,6 +458,10 @@ export class Config implements IConfig {
     ]).join('\n')
 
     process.emitWarning(JSON.stringify(err))
+  }
+
+  protected get isProd() {
+    return process.env.NODE_DEV !== 'development'
   }
 }
 

--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -190,7 +190,17 @@ export class Plugin implements IPlugin {
         if (cmd.default && cmd.default.run) return cmd.default
         return Object.values(cmd).find((cmd: any) => typeof cmd.run === 'function')
       }
-      const p = require.resolve(path.join(this.commandsDir, ...id.split(':')))
+      const mod = path.join(this.commandsDir, ...id.split(':'))
+      let p
+      try {
+        p = require.resolve(mod)
+      } catch (_) {
+        try {
+          p = require.resolve(`${mod}.js`)
+        } catch (_) {
+          p = require.resolve(`${mod}/index.js`)
+        }
+      }
       this._debug('require', p)
       let m
       try {

--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -112,8 +112,7 @@ export class Plugin implements IPlugin {
     this.name = this.pjson.name
     const pjsonPath = path.join(root, 'package.json')
     if (!this.name) throw new Error(`no name in ${pjsonPath}`)
-    const isProd = process.env.NODE_DEV !== 'development'
-    if (!isProd && !this.pjson.files) this.warn(`files attribute must be specified in ${pjsonPath}`)
+    if (process.env.NODE_DEV === 'development' && !this.pjson.files) this.warn(`files attribute must be specified in ${pjsonPath}`)
     // eslint-disable-next-line new-cap
     this._debug = Debug(this.name)
     this.version = this.pjson.version

--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -15,15 +15,6 @@ import {compact, exists, flatMap, loadJSON, mapValues} from './util'
 
 const _pjson = require('../../package.json')
 
-const hasManifest = function (p: string): boolean {
-  try {
-    require(p)
-    return true
-  } catch {
-    return false
-  }
-}
-
 function topicsToArray(input: any, base?: string): Topic[] {
   if (!input) return []
   base = base ? `${base}:` : ''
@@ -121,7 +112,7 @@ export class Plugin implements IPlugin {
     this.name = this.pjson.name
     const pjsonPath = path.join(root, 'package.json')
     if (!this.name) throw new Error(`no name in ${pjsonPath}`)
-    const isProd = hasManifest(path.join(root, 'oclif.manifest.json'))
+    const isProd = process.env.NODE_DEV !== 'development'
     if (!isProd && !this.pjson.files) this.warn(`files attribute must be specified in ${pjsonPath}`)
     // eslint-disable-next-line new-cap
     this._debug = Debug(this.name)

--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -190,17 +190,7 @@ export class Plugin implements IPlugin {
         if (cmd.default && cmd.default.run) return cmd.default
         return Object.values(cmd).find((cmd: any) => typeof cmd.run === 'function')
       }
-      const mod = path.join(this.commandsDir, ...id.split(':'))
-      let p
-      try {
-        p = require.resolve(mod)
-      } catch (_) {
-        try {
-          p = require.resolve(`${mod}.js`)
-        } catch (_) {
-          p = require.resolve(`${mod}/index.js`)
-        }
-      }
+      const p = require.resolve(path.join(this.commandsDir, ...id.split(':')))
       this._debug('require', p)
       let m
       try {

--- a/src/config/ts-node.ts
+++ b/src/config/ts-node.ts
@@ -41,6 +41,7 @@ export function tsPath(root: string, orig: string | undefined): string | undefin
 export function tsPath(root: string, orig: string | undefined): string | undefined {
   if (!orig) return orig
   orig = path.join(root, orig)
+  if (process.env.NODE_ENV !== 'development') return orig
   try {
     const tsconfig = loadTSConfig(root)
     if (!tsconfig) return orig

--- a/test/helpers/init.js
+++ b/test/helpers/init.js
@@ -1,4 +1,5 @@
 const path = require('path')
 process.env.TS_NODE_PROJECT = path.resolve('test/tsconfig.json')
+process.env.NODE_ENV = 'development'
 
 global.columns = 80


### PR DESCRIPTION
~~WIP do not merge~~

This change thus introduces the idea of explicit dev mode in oclif.

This also means we are now introducing two separate bin stubs for dev & prod `bin/dev` and `bin/run`.

bin/dev:
```
#!/usr/bin/env node

process.env.NODE_ENV = 'development'
const path = require('path')
const project = path.join(__dirname, '../tsconfig.json')
require('ts-node').register({project})
require('@oclif/core').run()
.then(require('@oclif/core/flush'))
.catch(require('@oclif/core/handle'))
```

bin/run:
```
#!/usr/bin/env node

require('@oclif/core').run()
.then(require('@oclif/core/flush'))
.catch(require('@oclif/core/handle'))

```