### PR TITLE
ESM quality of life improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript": "3.8.3"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12.0.0"
   },
   "files": [
     "/lib",

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,3 +1,5 @@
+import {fileURLToPath} from 'url'
+
 import {format, inspect} from 'util'
 
 import {Config} from './config'
@@ -76,6 +78,12 @@ export default abstract class Command {
    */
   static run: Interfaces.Command.Class['run'] = async function (this: Interfaces.Command.Class, argv?: string[], opts?) {
     if (!argv) argv = process.argv.slice(2)
+
+    // Handle the case when a file URL string is passed in such as 'import.meta.url'; covert to file path.
+    if (typeof opts === 'string' && opts.startsWith('file://')) {
+      opts = fileURLToPath(opts)
+    }
+
     const config = await Config.load(opts || (module.parent && module.parent.parent && module.parent.parent.filename) || __dirname)
     const cmd = new this(argv, config)
     return cmd._run(argv)

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -2,7 +2,7 @@ import {CLIError, error, exit, warn} from '../errors'
 import * as Lodash from 'lodash'
 import * as os from 'os'
 import * as path from 'path'
-import {URL} from 'url'
+import {fileURLToPath, URL} from 'url'
 import {format} from 'util'
 
 import {Options, Plugin as IPlugin} from '../interfaces/plugin'
@@ -96,6 +96,11 @@ export class Config implements IConfig {
   constructor(public options: Options) {}
 
   static async load(opts: LoadOptions = (module.parent && module.parent && module.parent.parent && module.parent.parent.filename) || __dirname) {
+    // Handle the case when a file URL string is passed in such as 'import.meta.url'; covert to file path.
+    if (typeof opts === 'string' && opts.startsWith('file://')) {
+      opts = fileURLToPath(opts)
+    }
+
     if (typeof opts === 'string') opts = {root: opts}
     if (isConfig(opts)) return opts
     const config = new Config(opts)

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import * as Parser from './parser'
 import {Hook} from './interfaces/hooks'
 import {settings, Settings} from './settings'
 
+const flush = require('../flush')
+
 export {
   Command,
   Config,
@@ -32,6 +34,7 @@ export {
   toConfiguredId,
   settings,
   Settings,
+  flush,
 }
 
 function checkCWD() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+import {fileURLToPath} from 'url'
+
 import {format, inspect} from 'util'
 
 import * as Interfaces from './interfaces'
@@ -25,6 +27,11 @@ const versionOverride = (argv: string[]): boolean => {
 }
 
 export async function run(argv = process.argv.slice(2), options?: Interfaces.LoadOptions) {
+  // Handle the case when a file URL string or URL is passed in such as 'import.meta.url'; covert to file path.
+  if ((typeof options === 'string' && options.startsWith('file://')) || options instanceof URL) {
+    options = fileURLToPath(options)
+  }
+
   // return Main.run(argv, options)
   const config = await Config.load(options || (module.parent && module.parent.parent && module.parent.parent.filename) || __dirname) as Config
 

--- a/test/command/fixtures/esm/package.json
+++ b/test/command/fixtures/esm/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "oclif-esm",
+  "version": "0.0.0",
+  "description": "base library for oclif CLIs w/ ESM",
+  "private": true,
+  "type": "module",
+  "files": [],
+  "oclif": {
+    "commands": "./src/commands",
+    "topicSeparator": " ",
+    "plugins": [
+      "@oclif/plugin-help",
+      "@oclif/plugin-plugins"
+    ],
+    "topics": {
+      "foo": {
+        "description": "foo topic description",
+        "subtopics": {
+          "bar": {
+            "description": "foo bar topic description"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/command/fixtures/esm/src/commands/foo/bar/fail.js
+++ b/test/command/fixtures/esm/src/commands/foo/bar/fail.js
@@ -1,0 +1,8 @@
+export class Command {
+  static description = 'fail description'
+
+  static run() {
+    console.log('it fails!')
+    throw new Error('random error')
+  }
+}

--- a/test/command/fixtures/esm/src/commands/foo/bar/succeed.js
+++ b/test/command/fixtures/esm/src/commands/foo/bar/succeed.js
@@ -1,0 +1,8 @@
+export class Command {
+  static description = 'succeed description'
+
+  static run() {
+    console.log('it works!')
+    return 'returned success!'
+  }
+}

--- a/test/command/fixtures/esm/src/commands/foo/baz.js
+++ b/test/command/fixtures/esm/src/commands/foo/baz.js
@@ -1,0 +1,7 @@
+export class Command {
+  static description = 'foo baz description'
+
+  static run() {
+    console.log('running Baz')
+  }
+}

--- a/test/command/main-esm.test.ts
+++ b/test/command/main-esm.test.ts
@@ -1,0 +1,93 @@
+import {expect, fancy} from 'fancy-test'
+import * as path from 'path'
+import * as url from 'url'
+
+import {run} from '../../src/main'
+
+// This tests file URL / import.meta.url simulation.
+const convertToFileURL = (filepath: string) => url.pathToFileURL(filepath).toString()
+
+let root = path.resolve(__dirname, '../../package.json')
+const pjson = require(root)
+const version = `@oclif/core/${pjson.version} ${process.platform}-${process.arch} node-${process.version}`
+
+root = convertToFileURL(root)
+
+describe('main-esm', () => {
+  fancy
+  .stdout()
+  .do(() => run(['plugins'], root))
+  .do((output: any) => expect(output.stdout).to.equal('no plugins installed\n'))
+  .it('runs plugins')
+
+  fancy
+  .stdout()
+  .do(() => run(['--version'], root))
+  .do((output: any) => expect(output.stdout).to.equal(version + '\n'))
+  .it('runs --version')
+
+  fancy
+  .stdout()
+  .do(() => run(['--help'], root))
+  .do((output: any) => expect(output.stdout).to.equal(`base library for oclif CLIs
+
+VERSION
+  ${version}
+
+USAGE
+  $ oclif [COMMAND]
+
+TOPICS
+  plugins  list installed plugins
+
+COMMANDS
+  help     display help for oclif
+  plugins  list installed plugins
+
+`))
+  .it('runs --help')
+
+  fancy
+  .stdout()
+  .do(() => run(['--help', 'foo'], convertToFileURL(path.resolve(__dirname, 'fixtures/esm/package.json'))))
+  .do((output: any) => expect(output.stdout).to.equal(`foo topic description
+
+USAGE
+  $ oclif-esm foo COMMAND
+
+TOPICS
+  foo bar  foo bar topic description
+
+COMMANDS
+  foo baz  foo baz description
+
+`))
+  .it('runs spaced topic help')
+
+  fancy
+  .stdout()
+  .do(() => run(['foo', 'bar', '--help'], convertToFileURL(path.resolve(__dirname, 'fixtures/esm/package.json'))))
+  .do((output: any) => expect(output.stdout).to.equal(`foo bar topic description
+
+USAGE
+  $ oclif-esm foo bar COMMAND
+
+COMMANDS
+  foo bar fail     fail description
+  foo bar succeed  succeed description
+
+`))
+  .it('runs spaced topic help v2')
+
+  fancy
+  .stdout()
+  .do(() => run(['foo', 'baz'], convertToFileURL(path.resolve(__dirname, 'fixtures/esm/package.json'))))
+  .do((output: any) => expect(output.stdout).to.equal('running Baz\n'))
+  .it('runs foo:baz with space separator')
+
+  fancy
+  .stdout()
+  .do(() => run(['foo', 'bar', 'succeed'], convertToFileURL(path.resolve(__dirname, 'fixtures/esm/package.json'))))
+  .do((output: any) => expect(output.stdout).to.equal('it works!\n'))
+  .it('runs foo:bar:succeed with space separator')
+})

--- a/test/config/esm.test.ts
+++ b/test/config/esm.test.ts
@@ -1,3 +1,4 @@
+import * as url from 'url'
 import * as path from 'path'
 
 import {Config} from '../../src/config'
@@ -7,8 +8,11 @@ import {expect, fancy} from './test'
 const root = path.resolve(__dirname, 'fixtures/esm')
 const p = (p: string) => path.join(root, p)
 
+// This tests file URL / import.meta.url simulation.
+const rootAsFileURL = url.pathToFileURL(root).toString()
+
 const withConfig = fancy
-.add('config', () => Config.load(root))
+.add('config', () => Config.load(rootAsFileURL))
 
 describe('esm', () => {
   withConfig


### PR DESCRIPTION
@amphro 
This rounds out ESM support for @oclif/core v2. 

ESM quality of life improvements:
- support file URL string as options input (IE 'import.meta.url').
- added `./flush.js` as an export from @oclif/core; `./src/index.ts`
- added main runtime ESM test w/ file URL as options.
- raised package.json Node engine level to `>= 12.0.0`. 

The added runtime tests focus on Main.run using a file URL as options. I also changed one of the Config ESM tests to use file URL as options as well. 

Please see the follow up message for a note about CommonJS deprecations when I raised the engine level to `>= 12.0.0`