### PR TITLE
feat: help improvments and customizability

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-* text=auto
-*.js text eol=lf
-*.ts text eol=lf

--- a/test/command/command.test.ts
+++ b/test/command/command.test.ts
@@ -27,7 +27,7 @@ describe('command', () => {
   fancy
   .stdout()
   .do(() => Command.run([]))
-  .do(output => expect(output.stdout).to.equal('foo' + EOL))
+  .do(output => expect(output.stdout).to.equal(`foo${EOL}`))
   .it('logs to stdout')
 
   fancy
@@ -215,7 +215,7 @@ describe('command', () => {
       }
 
       await CMD.run(['--foo=bar'])
-      expect(ctx.stdout).to.equal('bar' + EOL)
+      expect(ctx.stdout).to.equal(`bar${EOL}`)
     })
   })
 
@@ -230,7 +230,7 @@ describe('command', () => {
       }
       await CMD.run([])
     })
-    .do(ctx => expect(ctx.stdout).to.equal('json output: {"a":"foobar"}' + EOL))
+    .do(ctx => expect(ctx.stdout).to.equal(`json output: {"a":"foobar"}${EOL}`))
     .it('uses util.format()')
   })
 
@@ -259,7 +259,7 @@ describe('command', () => {
       }
       await CMD.run([])
     })
-    .do(ctx => expect(ctx.stdout).to.equal('json output: {"a":"foobar"}' + EOL))
+    .do(ctx => expect(ctx.stdout).to.equal(`json output: {"a":"foobar"}${EOL}`))
     .it('test stdout EPIPE swallowed')
   })
 })

--- a/test/command/main-esm.test.ts
+++ b/test/command/main-esm.test.ts
@@ -18,7 +18,7 @@ describe('main-esm', () => {
   fancy
   .stdout()
   .do(() => run(['plugins'], root))
-  .do((output: any) => expect(output.stdout).to.equal('no plugins installed' + EOL))
+  .do((output: any) => expect(output.stdout).to.equal('no plugins installed\n'))
   .it('runs plugins')
 
   fancy
@@ -83,12 +83,12 @@ COMMANDS
   fancy
   .stdout()
   .do(() => run(['foo', 'baz'], convertToFileURL(path.resolve(__dirname, 'fixtures/esm/package.json'))))
-  .do((output: any) => expect(output.stdout).to.equal('running Baz' + EOL))
+  .do((output: any) => expect(output.stdout).to.equal('running Baz\n'))
   .it('runs foo:baz with space separator')
 
   fancy
   .stdout()
   .do(() => run(['foo', 'bar', 'succeed'], convertToFileURL(path.resolve(__dirname, 'fixtures/esm/package.json'))))
-  .do((output: any) => expect(output.stdout).to.equal('it works!' + EOL))
+  .do((output: any) => expect(output.stdout).to.equal('it works!\n'))
   .it('runs foo:bar:succeed with space separator')
 })

--- a/test/command/main.test.ts
+++ b/test/command/main.test.ts
@@ -12,7 +12,7 @@ describe('main', () => {
   fancy
   .stdout()
   .do(() => run(['plugins'], root))
-  .do((output: any) => expect(output.stdout).to.equal('no plugins installed' + EOL))
+  .do((output: any) => expect(output.stdout).to.equal('no plugins installed\n'))
   .it('runs plugins')
 
   fancy
@@ -77,12 +77,12 @@ COMMANDS
   fancy
   .stdout()
   .do(() => run(['foo', 'baz'], path.resolve(__dirname, 'fixtures/typescript/package.json')))
-  .do((output: any) => expect(output.stdout).to.equal('running Baz' + EOL))
+  .do((output: any) => expect(output.stdout).to.equal('running Baz\n'))
   .it('runs foo:baz with space separator')
 
   fancy
   .stdout()
   .do(() => run(['foo', 'bar', 'succeed'], path.resolve(__dirname, 'fixtures/typescript/package.json')))
-  .do((output: any) => expect(output.stdout).to.equal('it works!' + EOL))
+  .do((output: any) => expect(output.stdout).to.equal('it works!\n'))
   .it('runs foo:bar:succeed with space separator')
 })

--- a/test/config/esm.test.ts
+++ b/test/config/esm.test.ts
@@ -4,7 +4,6 @@ import * as path from 'path'
 import {Config} from '../../src/config'
 
 import {expect, fancy} from './test'
-import {EOL} from 'os'
 
 const root = path.resolve(__dirname, 'fixtures/esm')
 const p = (p: string) => path.join(root, p)
@@ -27,7 +26,7 @@ describe('esm', () => {
   .stdout()
   .it('runs esm command and prerun & postrun hooks', async ctx => {
     await ctx.config.runCommand('foo:bar:baz')
-    expect(ctx.stdout).to.equal(`running esm prerun hook${EOL}it works!${EOL}running esm postrun hook${EOL}`)
+    expect(ctx.stdout).to.equal('running esm prerun hook\nit works!\nrunning esm postrun hook\n')
   })
 
   withConfig
@@ -38,20 +37,20 @@ describe('esm', () => {
     } catch {
       console.log('caught error')
     }
-    expect(ctx.stdout).to.equal(`running esm prerun hook${EOL}it fails!${EOL}caught error${EOL}`)
+    expect(ctx.stdout).to.equal('running esm prerun hook\nit fails!\ncaught error\n')
   })
 
   withConfig
   .stdout()
   .it('runs esm command, postrun hook captures command result', async ctx => {
     await ctx.config.runCommand('foo:bar:test-result')
-    expect(ctx.stdout).to.equal(`running esm prerun hook${EOL}it works!${EOL}running esm postrun hook${EOL}returned success!${EOL}`)
+    expect(ctx.stdout).to.equal('running esm prerun hook\nit works!\nrunning esm postrun hook\nreturned success!\n')
   })
 
   withConfig
   .stdout()
   .it('runs init hook', async ctx => {
     await (ctx.config.runHook as any)('init', {id: 'myid', argv: ['foo']})
-    expect(ctx.stdout).to.equal('running esm init hook' + EOL)
+    expect(ctx.stdout).to.equal('running esm init hook\n')
   })
 })

--- a/test/config/mixed-cjs-esm.test.ts
+++ b/test/config/mixed-cjs-esm.test.ts
@@ -1,4 +1,3 @@
-import {EOL} from 'os'
 import * as path from 'path'
 
 import {Config} from '../../src/config'
@@ -23,7 +22,7 @@ describe('mixed-cjs-esm', () => {
   .stdout()
   .it('runs mixed-cjs-esm command and prerun & postrun hooks', async ctx => {
     await ctx.config.runCommand('foo:bar:baz')
-    expect(ctx.stdout).to.equal(`running mixed-cjs-esm prerun hook${EOL}it works!${EOL}running mixed-cjs-esm postrun hook${EOL}`)
+    expect(ctx.stdout).to.equal('running mixed-cjs-esm prerun hook\nit works!\nrunning mixed-cjs-esm postrun hook\n')
   })
 
   withConfig
@@ -34,20 +33,20 @@ describe('mixed-cjs-esm', () => {
     } catch {
       console.log('caught error')
     }
-    expect(ctx.stdout).to.equal(`running mixed-cjs-esm prerun hook${EOL}it fails!${EOL}caught error${EOL}`)
+    expect(ctx.stdout).to.equal('running mixed-cjs-esm prerun hook\nit fails!\ncaught error\n')
   })
 
   withConfig
   .stdout()
   .it('runs mixed-cjs-esm command, postrun hook captures command result', async ctx => {
     await ctx.config.runCommand('foo:bar:test-result')
-    expect(ctx.stdout).to.equal(`running mixed-cjs-esm prerun hook${EOL}it works!${EOL}running mixed-cjs-esm postrun hook${EOL}returned success!${EOL}`)
+    expect(ctx.stdout).to.equal('running mixed-cjs-esm prerun hook\nit works!\nrunning mixed-cjs-esm postrun hook\nreturned success!\n')
   })
 
   withConfig
   .stdout()
   .it('runs init hook', async ctx => {
     await (ctx.config.runHook as any)('init', {id: 'myid', argv: ['foo']})
-    expect(ctx.stdout).to.equal('running mixed-cjs-esm init hook' + EOL)
+    expect(ctx.stdout).to.equal('running mixed-cjs-esm init hook\n')
   })
 })

--- a/test/config/mixed-esm-cjs.test.ts
+++ b/test/config/mixed-esm-cjs.test.ts
@@ -1,4 +1,3 @@
-import {EOL} from 'os'
 import * as path from 'path'
 
 import {Config} from '../../src/config'
@@ -23,7 +22,7 @@ describe('mixed-cjs-esm', () => {
   .stdout()
   .it('runs mixed-esm-cjs command and prerun & postrun hooks', async ctx => {
     await ctx.config.runCommand('foo:bar:baz')
-    expect(ctx.stdout).to.equal(`running mixed-esm-cjs prerun hook${EOL}it works!${EOL}running mixed-esm-cjs postrun hook${EOL}`)
+    expect(ctx.stdout).to.equal('running mixed-esm-cjs prerun hook\nit works!\nrunning mixed-esm-cjs postrun hook\n')
   })
 
   withConfig
@@ -34,20 +33,20 @@ describe('mixed-cjs-esm', () => {
     } catch {
       console.log('caught error')
     }
-    expect(ctx.stdout).to.equal(`running mixed-esm-cjs prerun hook${EOL}it fails!${EOL}caught error${EOL}`)
+    expect(ctx.stdout).to.equal('running mixed-esm-cjs prerun hook\nit fails!\ncaught error\n')
   })
 
   withConfig
   .stdout()
   .it('runs mixed-esm-cjs command, postrun hook captures command result', async ctx => {
     await ctx.config.runCommand('foo:bar:test-result')
-    expect(ctx.stdout).to.equal(`running mixed-esm-cjs prerun hook${EOL}it works!${EOL}running mixed-esm-cjs postrun hook${EOL}returned success!${EOL}`)
+    expect(ctx.stdout).to.equal('running mixed-esm-cjs prerun hook\nit works!\nrunning mixed-esm-cjs postrun hook\nreturned success!\n')
   })
 
   withConfig
   .stdout()
   .it('runs init hook', async ctx => {
     await (ctx.config.runHook as any)('init', {id: 'myid', argv: ['foo']})
-    expect(ctx.stdout).to.equal('running mixed-esm-cjs init hook' + EOL)
+    expect(ctx.stdout).to.equal('running mixed-esm-cjs init hook\n')
   })
 })

--- a/test/config/typescript.test.ts
+++ b/test/config/typescript.test.ts
@@ -1,4 +1,3 @@
-import {EOL} from 'os'
 import * as path from 'path'
 
 import {Config} from '../../src/config'
@@ -23,7 +22,7 @@ describe('typescript', () => {
   .stdout()
   .it('runs ts command and prerun & postrun hooks', async ctx => {
     await ctx.config.runCommand('foo:bar:baz')
-    expect(ctx.stdout).to.equal(`running ts prerun hook${EOL}it works!${EOL}running ts postrun hook${EOL}`)
+    expect(ctx.stdout).to.equal('running ts prerun hook\nit works!\nrunning ts postrun hook\n')
   })
 
   withConfig
@@ -34,14 +33,14 @@ describe('typescript', () => {
     } catch {
       console.log('caught error')
     }
-    expect(ctx.stdout).to.equal(`running ts prerun hook${EOL}it fails!${EOL}caught error${EOL}`)
+    expect(ctx.stdout).to.equal('running ts prerun hook\nit fails!\ncaught error\n')
   })
 
   withConfig
   .stdout()
   .it('runs ts command, postrun hook captures command result', async ctx => {
     await ctx.config.runCommand('foo:bar:test-result')
-    expect(ctx.stdout).to.equal(`running ts prerun hook${EOL}it works!${EOL}running ts postrun hook${EOL}returned success!${EOL}`)
+    expect(ctx.stdout).to.equal('running ts prerun hook\nit works!\nrunning ts postrun hook\nreturned success!\n')
   })
 
   withConfig
@@ -49,6 +48,6 @@ describe('typescript', () => {
   .it('runs init hook', async ctx => {
     // to-do: fix union types
     await (ctx.config.runHook as any)('init', {id: 'myid', argv: ['foo']})
-    expect(ctx.stdout).to.equal('running ts init hook' + EOL)
+    expect(ctx.stdout).to.equal('running ts init hook\n')
   })
 })

--- a/test/errors/handle.test.ts
+++ b/test/errors/handle.test.ts
@@ -7,7 +7,6 @@ import * as process from 'process'
 import {CLIError, config, ExitError} from '../../src/errors'
 import {handle} from '../../src/errors/handle'
 import {exit as exitErrorThrower} from '../../src/errors'
-import {EOL} from 'os'
 
 const errlog = path.join(__dirname, '../tmp/mytest/error.log')
 const x = process.platform === 'win32' ? '»' : '›'
@@ -26,6 +25,41 @@ describe('handle', () => {
     (process as any).exit = originalExit;
     (process as any).exitCode = originalExitCode
   })
+
+  // fancy
+  // .stderr()
+  // .finally(() => delete process.exitCode)
+  // .it('displays an error from root handle module', ctx => {
+  //   handle(new Error('x'))
+  //   expect(ctx.stderr).to.contain('Error: x')
+  //   expect(process.exitCode).to.equal(1)
+  // })
+
+  // fancy
+  // .stderr()
+  // .finally(() => delete process.exitCode)
+  // .it('shows an unhandled error', ctx => {
+  //   handle(new Error('x'))
+  //   expect(ctx.stderr).to.contain('Error: x')
+  //   expect(process.exitCode).to.equal(1)
+  // })
+
+  // fancy
+  // .stderr()
+  // .finally(() => delete process.exitCode)
+  // .it('handles a badly formed error object', () => {
+  //   handle({status: 400} as any)
+  //   expect(process.exitCode).to.equal(1)
+  // })
+
+  // fancy
+  // .stderr()
+  // .finally(() => delete process.exitCode)
+  // .it('shows a cli error', ctx => {
+  //   handle(new CLIError('x'))
+  //   expect(ctx.stderr).to.equal(` ${x}   Error: x\n`)
+  //   expect(process.exitCode).to.equal(2)
+  // })
 
   fancy
   .stdout()
@@ -49,7 +83,7 @@ describe('handle', () => {
   .finally(() => delete process.exitCode)
   .it('logs when errlog is set', async ctx => {
     handle(new CLIError('uh oh!'))
-    expect(ctx.stderr).to.equal(` ${x}   Error: uh oh!${EOL}`)
+    expect(ctx.stderr).to.equal(` ${x}   Error: uh oh!\n`)
     await config.errorLogger!.flush()
     expect(fs.readFileSync(errlog, 'utf8')).to.contain('Error: uh oh!')
     expect(process.exitCode).to.equal(2)

--- a/test/help/format-command-with-options.test.ts
+++ b/test/help/format-command-with-options.test.ts
@@ -1,5 +1,4 @@
 import {expect, test as base} from '@oclif/test'
-import {EOL} from 'os'
 import stripAnsi = require('strip-ansi')
 
 import {Command as Base, Flags as flags, Interfaces, toCached} from '../../src'
@@ -52,7 +51,7 @@ const test = base
     if (process.env.TEST_OUTPUT === '1') {
       console.log(help)
     }
-    ctx.commandHelp = stripAnsi(help).split(EOL).map(s => s.trimRight()).join(EOL)
+    ctx.commandHelp = stripAnsi(help).split('\n').map(s => s.trimRight()).join('\n')
     ctx.expectation = 'has commandHelp'
   },
 }))
@@ -73,7 +72,7 @@ multiline help`
         app: flags.string({char: 'a', hidden: true}),
         foo: flags.string({char: 'f', description: 'foobar'.repeat(18)}),
         force: flags.boolean({description: 'force  it '.repeat(15)}),
-        ss: flags.boolean({description: `newliney${EOL}`.repeat(4)}),
+        ss: flags.boolean({description: 'newliney\n'.repeat(4)}),
         remote: flags.string({char: 'r'}),
         label: flags.string({char: 'l', helpLabel: '-l'}),
       }
@@ -123,7 +122,7 @@ ALIASES
           app: flags.string({char: 'a', hidden: true}),
           foo: flags.string({char: 'f', description: 'foobar'.repeat(15)}),
           force: flags.boolean({description: 'force  it '.repeat(15)}),
-          ss: flags.boolean({description: `newliney${EOL}`.repeat(4)}),
+          ss: flags.boolean({description: 'newliney\n'.repeat(4)}),
           remote: flags.string({char: 'r'}),
         }
     })
@@ -171,7 +170,7 @@ ALIASES
           app: flags.string({char: 'a', hidden: true}),
           foo: flags.string({char: 'f', description: 'foobar'.repeat(20)}),
           force: flags.boolean({description: 'force  it '.repeat(29)}),
-          ss: flags.boolean({description: `newliney${EOL}`.repeat(5)}),
+          ss: flags.boolean({description: 'newliney\n'.repeat(5)}),
           remote: flags.string({char: 'r'}),
         }
     })
@@ -216,7 +215,7 @@ ALIASES
     .commandHelp(class extends Command {
         static id = 'apps:create'
 
-        static description = `description of apps:create${EOL}these values are after and will show up in the command description`
+        static description = 'description of apps:create\nthese values are after and will show up in the command description'
 
         static aliases = ['app:init', 'create']
 
@@ -226,7 +225,7 @@ ALIASES
           force: flags.boolean({description: 'forces'}),
         }
     })
-    .it('outputs command description with values after a EOL character', (ctx: any) => expect(ctx.commandHelp).to.equal(`USAGE
+    .it('outputs command description with values after a \\n newline character', (ctx: any) => expect(ctx.commandHelp).to.equal(`USAGE
   $ oclif apps:create [APP_NAME]
 
 ARGUMENTS
@@ -246,7 +245,7 @@ ALIASES
     .commandHelp(class extends Command {
         static id = 'apps:create'
 
-        static description = `root part of the description${EOL}The <%= config.bin %> CLI has <%= command.id %>`
+        static description = 'root part of the description\nThe <%= config.bin %> CLI has <%= command.id %>'
     })
     .it('renders template string from description', (ctx: any) => expect(ctx.commandHelp).to.equal(`USAGE
   $ oclif apps:create
@@ -414,7 +413,7 @@ EXAMPLES
     .commandHelp(class extends Command {
         static id = 'oclif:command'
 
-        static examples = [`Prints out help.${EOL}<%= config.bin %> <%= command.id %> --help`]
+        static examples = ['Prints out help.\n<%= config.bin %> <%= command.id %> --help']
     })
     .it('formats if command with description', (ctx: any) => expect(ctx.commandHelp).to.equal(`USAGE
   $ oclif oclif:command

--- a/test/help/format-command.test.ts
+++ b/test/help/format-command.test.ts
@@ -1,5 +1,4 @@
 import {expect, test as base} from '@oclif/test'
-import {EOL} from 'os'
 import stripAnsi = require('strip-ansi')
 
 import {Command as Base, Flags as flags, Interfaces, toCached} from '../../src'
@@ -31,7 +30,7 @@ const test = base
     if (process.env.TEST_OUTPUT === '1') {
       console.log(help)
     }
-    ctx.commandHelp = stripAnsi(help).split(EOL).map(s => s.trimRight()).join(EOL)
+    ctx.commandHelp = stripAnsi(help).split('\n').map(s => s.trimRight()).join('\n')
     ctx.expectation = 'has commandHelp'
   },
 }))
@@ -52,7 +51,7 @@ multiline help`
         app: flags.string({char: 'a', hidden: true}),
         foo: flags.string({char: 'f', description: 'foobar'.repeat(18)}),
         force: flags.boolean({description: 'force  it '.repeat(15)}),
-        ss: flags.boolean({description: `newliney${EOL}`.repeat(4)}),
+        ss: flags.boolean({description: 'newliney\n'.repeat(4)}),
         remote: flags.string({char: 'r'}),
         label: flags.string({char: 'l', helpLabel: '-l'}),
       }
@@ -107,7 +106,7 @@ ALIASES
           app: flags.string({char: 'a', hidden: true}),
           foo: flags.string({char: 'f', description: 'foobar'.repeat(15)}),
           force: flags.boolean({description: 'force  it '.repeat(15)}),
-          ss: flags.boolean({description: `newliney${EOL}`.repeat(4)}),
+          ss: flags.boolean({description: 'newliney\n'.repeat(4)}),
           remote: flags.string({char: 'r'}),
         }
     })
@@ -161,7 +160,7 @@ ALIASES
           app: flags.string({char: 'a', hidden: true}),
           foo: flags.string({char: 'f', description: 'foobar'.repeat(20)}),
           force: flags.boolean({description: 'force  it '.repeat(29)}),
-          ss: flags.boolean({description: `newliney${EOL}`.repeat(5)}),
+          ss: flags.boolean({description: 'newliney\n'.repeat(5)}),
           remote: flags.string({char: 'r'}),
         }
     })
@@ -212,7 +211,7 @@ ALIASES
     .commandHelp(class extends Command {
         static id = 'apps:create'
 
-        static description = `description of apps:create${EOL}these values are after and will show up in the command description`
+        static description = 'description of apps:create\nthese values are after and will show up in the command description'
 
         static aliases = ['app:init', 'create']
 
@@ -222,7 +221,7 @@ ALIASES
           force: flags.boolean({description: 'forces'}),
         }
     })
-    .it('outputs command description with values after a EOL character', (ctx: any) => expect(ctx.commandHelp).to.equal(`USAGE
+    .it('outputs command description with values after a \\n newline character', (ctx: any) => expect(ctx.commandHelp).to.equal(`USAGE
   $ oclif apps:create [APP_NAME]
 
 ARGUMENTS
@@ -247,7 +246,7 @@ ALIASES
     .commandHelp(class extends Command {
         static id = 'apps:create'
 
-        static description = `root part of the description${EOL}The <%= config.bin %> CLI has <%= command.id %>`
+        static description = 'root part of the description\nThe <%= config.bin %> CLI has <%= command.id %>'
 
         static disableJsonFlag = true
     })
@@ -356,7 +355,7 @@ FLAGS
         static flags = {
           opt: flags.string({
             summary: 'one line summary',
-            description: `multiline${EOL}description`,
+            description: 'multiline\ndescription',
           }),
         }
     })
@@ -507,7 +506,7 @@ EXAMPLES
     .commandHelp(class extends Command {
         static id = 'oclif:command'
 
-        static examples = [`Prints out help.${EOL}<%= config.bin %> <%= command.id %> --help`]
+        static examples = ['Prints out help.\n<%= config.bin %> <%= command.id %> --help']
     })
     .it('formats if command with description', (ctx: any) => expect(ctx.commandHelp).to.equal(`USAGE
   $ oclif oclif:command

--- a/test/help/format-commands.test.ts
+++ b/test/help/format-commands.test.ts
@@ -6,7 +6,6 @@ const g: any = global
 g.oclif.columns = 80
 import {Help} from '../../src/help'
 import {AppsDestroy, AppsCreate} from './fixtures/fixtures'
-import {EOL} from 'os'
 
 // extensions to expose method as public for testing
 class TestHelp extends Help {
@@ -25,7 +24,7 @@ const test = base
       console.log(help)
     }
 
-    ctx.output = stripAnsi(help).split(EOL).map(s => s.trimRight()).join(EOL)
+    ctx.output = stripAnsi(help).split('\n').map(s => s.trimRight()).join('\n')
   },
 }))
 

--- a/test/help/format-root.test.ts
+++ b/test/help/format-root.test.ts
@@ -3,7 +3,6 @@ import stripAnsi = require('strip-ansi')
 
 import {Help} from '../../src/help'
 import {Interfaces} from '../../src'
-import {EOL} from 'os'
 
 const g: any = global
 g.oclif.columns = 80
@@ -29,7 +28,7 @@ const test = base
     if (process.env.TEST_OUTPUT === '1') {
       console.log(help)
     }
-    ctx.commandHelp = stripAnsi(root).split(EOL).map(s => s.trimRight()).join(EOL)
+    ctx.commandHelp = stripAnsi(root).split('\n').map(s => s.trimRight()).join('\n')
   },
 }))
 
@@ -51,11 +50,11 @@ USAGE
         ...config,
         pjson: {
           ...config.pjson,
-          description: `This is the top-level description that appears in the root${EOL}This appears in the description section after usage`,
+          description: 'This is the top-level description that appears in the root\nThis appears in the description section after usage',
         },
       }
     })
-    .it('splits on EOL for the description into the top-level and description sections', ctx => {
+    .it('splits on \\n for the description into the top-level and description sections', ctx => {
       expect(ctx.commandHelp).to.equal(`This is the top-level description that appears in the root
 
 VERSION
@@ -74,7 +73,7 @@ DESCRIPTION
         ...config,
         pjson: {
           ...config.pjson,
-          description: `This is the top-level description for <%= config.bin %>${EOL}This <%= config.bin %> appears in the description section after usage`,
+          description: 'This is the top-level description for <%= config.bin %>\nThis <%= config.bin %> appears in the description section after usage',
         },
       }
     })

--- a/test/help/format-topic.test.ts
+++ b/test/help/format-topic.test.ts
@@ -3,7 +3,6 @@ import stripAnsi = require('strip-ansi')
 
 import {Help} from '../../src/help'
 import {Interfaces} from '../../src'
-import {EOL} from 'os'
 
 const g: any = global
 g.oclif.columns = 80
@@ -26,7 +25,7 @@ const test = base
     if (process.env.TEST_OUTPUT === '1') {
       console.log(topicHelpOutput)
     }
-    ctx.commandHelp = stripAnsi(topicHelpOutput).split(EOL).map(s => s.trimRight()).join(EOL)
+    ctx.commandHelp = stripAnsi(topicHelpOutput).split('\n').map(s => s.trimRight()).join('\n')
     ctx.expectation = 'has topicHelp'
   },
 }))
@@ -57,9 +56,9 @@ USAGE
   .topicHelp({
     name: 'topic',
     hidden: false,
-    description: `This is the top level description${EOL}Description that shows up in the DESCRIPTION section`,
+    description: 'This is the top level description\nDescription that shows up in the DESCRIPTION section',
   })
-  .it('shows topic descriptions split from EOL for top-level and description section descriptions', ctx => expect(ctx.commandHelp).to.equal(`This is the top level description
+  .it('shows topic descriptions split from \\n for top-level and description section descriptions', ctx => expect(ctx.commandHelp).to.equal(`This is the top level description
 
 USAGE
   $ oclif topic:COMMAND
@@ -71,9 +70,9 @@ DESCRIPTION
   .topicHelp({
     name: 'topic',
     hidden: false,
-    description: `<%= config.bin %>: This is the top level description${EOL}<%= config.bin %>: Description that shows up in the DESCRIPTION section`,
+    description: '<%= config.bin %>: This is the top level description\n<%= config.bin %>: Description that shows up in the DESCRIPTION section',
   })
-  .it('shows topic descriptions split from EOL for top-level and description section descriptions', ctx => expect(ctx.commandHelp).to.equal(`oclif: This is the top level description
+  .it('shows topic descriptions split from \\n for top-level and description section descriptions', ctx => expect(ctx.commandHelp).to.equal(`oclif: This is the top level description
 
 USAGE
   $ oclif topic:COMMAND

--- a/test/help/format-topics.test.ts
+++ b/test/help/format-topics.test.ts
@@ -3,7 +3,6 @@ import stripAnsi = require('strip-ansi')
 
 import {Help} from '../../src/help'
 import {Interfaces} from '../../src'
-import {EOL} from 'os'
 
 const g: any = global
 g.oclif.columns = 80
@@ -26,7 +25,7 @@ const test = base
       console.log(topicsHelpOutput)
     }
 
-    ctx.commandHelp = stripAnsi(topicsHelpOutput).split(EOL).map(s => s.trimRight()).join(EOL)
+    ctx.commandHelp = stripAnsi(topicsHelpOutput).split('\n').map(s => s.trimRight()).join('\n')
     ctx.expectation = 'has topicsHelp'
   },
 }))

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -3,7 +3,6 @@ import {expect} from 'chai'
 
 import {flags, parse} from '../../src/parser'
 import {Interfaces} from '../../src'
-import {EOL} from 'os'
 
 describe('parse', () => {
   it('--bool', async () => {
@@ -129,7 +128,7 @@ describe('parse', () => {
         message = error.message
       }
       expect(message).to.equal(
-        `Missing required flag:${EOL} --myflag MYFLAG  flag description${EOL}See more help with --help`,
+        'Missing required flag:\n --myflag MYFLAG  flag description\nSee more help with --help',
       )
     })
 
@@ -179,7 +178,7 @@ See more help with --help`)
         } catch (error) {
           message = error.message
         }
-        expect(message).to.equal(`Unexpected argument: arg2${EOL}See more help with --help`)
+        expect(message).to.equal('Unexpected argument: arg2\nSee more help with --help')
       })
 
       it('parses args', async () => {
@@ -638,7 +637,7 @@ See more help with --help`)
       } catch (error) {
         message = error.message
       }
-      expect(message).to.equal(`Expected --foo=invalidopt to be one of: myopt, myotheropt${EOL}See more help with --help`)
+      expect(message).to.equal('Expected --foo=invalidopt to be one of: myopt, myotheropt\nSee more help with --help')
     })
   })
 
@@ -681,7 +680,7 @@ See more help with --help`)
       } catch (error) {
         message = error.message
       }
-      expect(message).to.equal(`Expected invalidopt to be one of: myopt, myotheropt${EOL}See more help with --help`)
+      expect(message).to.equal('Expected invalidopt to be one of: myopt, myotheropt\nSee more help with --help')
     })
   })
 


### PR DESCRIPTION
Reverts some of the EOL changes to allow tests to run on Windows.

Note that there are still a bunch of failing tests due to `\r\n` vs `\n` but at least they actually run to completion now and tell you the expected vs actual output.