### PR TITLE
fix: account for aliases when converting spaced commands to commandID

### DIFF
--- a/src/help/util.ts
+++ b/src/help/util.ts
@@ -48,7 +48,14 @@ function collateSpacedCmdIDFromArgs(argv: string[], config: IConfig): string[] {
     const finalizeId = (s?: string) => s ? [...final, s].join(':') : final.join(':')
 
     const hasSubCommandsWithArgs = () => {
-      const subCommands = config.commands.filter(c => (c.id).startsWith(finalizeId()))
+      const id = finalizeId()
+      /**
+       * Get a list of sub commands for the current command id. A command is returned as a subcommand under either
+       * of these conditions:
+       * 1. the `id` start with the current command id.
+       * 2. any of the aliases start with the current command id.
+       */
+      const subCommands = config.commands.filter(c => (c.id).startsWith(id) || c.aliases.some(a => a.startsWith(id)))
       return Boolean(subCommands.find(cmd => cmd.strict === false || cmd.args?.length > 0))
     }
 


### PR DESCRIPTION
`collateSpacedCmdIDFromArgs` failed to account for aliases when converting spaced commands to the normalized `commandID`. This PR fixes that.

[skip-validate-pr]