### PR TITLE
fix: improve Hooks interface

### DIFF
--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -1,5 +1,5 @@
 import {PJSON} from './pjson'
-import {Hooks} from './hooks'
+import {Hooks, Hook} from './hooks'
 import {Command} from './command'
 import {Plugin, Options} from './plugin'
 import {Topic} from './topic'
@@ -95,7 +95,7 @@ export interface Config {
 
   runCommand<T = unknown>(id: string, argv?: string[]): Promise<T>;
   runCommand<T = unknown>(id: string, argv?: string[], cachedCommand?: Command.Plugin): Promise<T>;
-  runHook<T extends Hooks, K extends Extract<keyof T, string>>(event: K, opts: T[K]): Promise<any>;
+  runHook<T extends keyof Hooks>(event: T, opts: Hooks[T]['options'], timeout?: number): Promise<Hook.Result<Hooks[T]['return']>>;
   findCommand(id: string, opts: { must: true }): Command.Plugin;
   findCommand(id: string, opts?: { must: boolean }): Command.Plugin | undefined;
   findTopic(id: string, opts: { must: true }): Topic;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -3,7 +3,7 @@ export {Config, ArchTypes, PlatformTypes, LoadOptions} from './config'
 export {Command, Example} from './command'
 export {OclifError, PrettyPrintableError} from './errors'
 export {HelpOptions} from './help'
-export {Hook, HookKeyOrOptions, Hooks} from './hooks'
+export {Hook, Hooks} from './hooks'
 export {Manifest} from './manifest'
 export {
   ParserArg, Arg, ParseFn, ParserOutput, ParserInput, ArgToken,


### PR DESCRIPTION
Improves the `Hooks` interface so that:
1. Users can extend `Hooks` to add their own hooks
2. `runHook` now expects a return type based on the `Hooks`
3. Adds a `timeout` parameter to `runHook`
4. `runHook` now returns successes and failures

### Example of Extending `Hooks`

```typescript
interface SfHooks extends Hooks {
  'env:list': { options: {}; return: Environment[] };
  'env:display': { options: {}; return: Environment };
}

export namespace SfHook {
  export type EnvList = Hook<'env:list', SfHooks>;
  export type EnvDisplay = Hook<'env:display', SfHooks>;
}

const hook: SfHook.EnvList = async function () {
  return [
    { name: 'foo', active: true },
    { name: 'bar', active: false },
  ];
};

```

### Example of Improved Typing

![Screen Shot 2021-08-27 at 9 07 45 AM](https://user-images.githubusercontent.com/10244328/131149172-48e16f6c-5a34-4ef2-9056-cd4971f5bc33.png)

![Screen Shot 2021-08-27 at 9 04 05 AM](https://user-images.githubusercontent.com/10244328/131149180-cbefc028-a00e-4cdc-a56e-a7ed3b07afba.png)


@W-9811480@