### PR TITLE
Replace Chalk with Nano Colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "bugs": "https://github.com/oclif/core/issues",
   "dependencies": {
     "@oclif/linewrap": "^1.0.0",
-    "chalk": "^4.1.0",
     "clean-stack": "^3.0.0",
     "cli-ux": "^5.1.0",
     "debug": "^4.1.1",
@@ -16,6 +15,7 @@
     "indent-string": "^4.0.0",
     "is-wsl": "^2.1.1",
     "lodash.template": "^4.4.0",
+    "nanocolors": "^0.2.2",
     "semver": "^7.3.2",
     "string-width": "^4.2.0",
     "strip-ansi": "^6.0.0",

--- a/src/command.ts
+++ b/src/command.ts
@@ -230,8 +230,8 @@ export default abstract class Command {
       if (!err.message) throw err
       try {
         const {cli} = require('cli-ux')
-        const chalk = require('chalk') // eslint-disable-line node/no-extraneous-require
-        cli.action.stop(chalk.bold.red('!'))
+        const {bold, red} = require('nanocolors') // eslint-disable-line node/no-extraneous-require
+        cli.action.stop(bold(red('!')))
       } catch {}
       throw err
     }

--- a/src/errors/errors/cli.ts
+++ b/src/errors/errors/cli.ts
@@ -1,6 +1,6 @@
 // tslint:disable no-implicit-dependencies
 
-import * as Chalk from 'chalk'
+import {red, yellow} from 'nanocolors'
 import Clean = require('clean-stack')
 import Indent = require('indent-string')
 import * as Wrap from 'wrap-ansi'
@@ -58,10 +58,6 @@ export class CLIError extends Error implements OclifError {
   }
 
   get bang() {
-    let red: typeof Chalk.red = ((s: string) => s) as any
-    try {
-      red = require('chalk').red
-    } catch { }
     return red(process.platform === 'win32' ? '»' : '›')
   }
 }
@@ -74,10 +70,6 @@ export namespace CLIError {
     }
 
     get bang() {
-      let yellow: typeof Chalk.yellow = ((s: string) => s) as any
-      try {
-        yellow = require('chalk').yellow
-      } catch { }
       return yellow(process.platform === 'win32' ? '»' : '›')
     }
   }

--- a/src/help/command.ts
+++ b/src/help/command.ts
@@ -1,4 +1,4 @@
-import * as Chalk from 'chalk'
+import * as NanoColors from 'nanocolors'
 import stripAnsi = require('strip-ansi')
 
 import {castArray, compact, sortBy} from '../util'
@@ -14,13 +14,13 @@ const POSSIBLE_LINE_FEED = /\r\n|\n/
 
 const {
   underline,
-} = Chalk
+} = NanoColors
 let {
   dim,
-} = Chalk
+} = NanoColors
 
 if (process.env.ConEmuANSI === 'ON') {
-  dim = Chalk.gray
+  dim = NanoColors.gray
 }
 export class CommandHelp extends HelpFormatter {
   constructor(

--- a/src/help/formatter.ts
+++ b/src/help/formatter.ts
@@ -1,4 +1,4 @@
-import * as Chalk from 'chalk'
+import * as NanoColors from 'nanocolors'
 import indent = require('indent-string')
 import stripAnsi = require('strip-ansi')
 
@@ -12,7 +12,7 @@ const widestLine = require('widest-line')
 const wrap = require('wrap-ansi')
 const {
   bold,
-} = Chalk
+} = NanoColors
 
 export type HelpSectionKeyValueTable = {name: string; description: string}[]
 export type HelpSection = {header: string; body: string | HelpSectionKeyValueTable | [string, string | undefined][] | undefined} | undefined;

--- a/src/parser/help.ts
+++ b/src/parser/help.ts
@@ -1,4 +1,4 @@
-import * as Chalk from 'chalk'
+import {Colors} from 'nanocolors'
 
 import Deps from './deps'
 import * as Util from './util'
@@ -6,7 +6,7 @@ import {FlagUsageOptions, Flag} from '../interfaces'
 
 // eslint-disable-next-line new-cap
 const m = Deps()
-.add('chalk', () => require('chalk') as typeof Chalk)
+.add('nanocolors', () => require('nanocolors') as Colors)
 // eslint-disable-next-line node/no-missing-require
 .add('util', () => require('./util') as typeof Util)
 
@@ -24,7 +24,7 @@ export function flagUsage(flag: Flag<any>, options: FlagUsageOptions = {}): [str
 
   let description: string | undefined = flag.summary || flag.description || ''
   if (options.displayRequired && flag.required) description = `(required) ${description}`
-  description = description ? m.chalk.dim(description) : undefined
+  description = description ? m.nanocolors.dim(description) : undefined
 
   return [` ${label.join(',').trim()}${usage}`, description] as [string, string | undefined]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2437,6 +2437,11 @@ ms@2.1.3, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+nanocolors@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.2.tgz#94a4b7e45ecdebdbea7cb0a8349f9447a9677675"
+  integrity sha512-t4mwdKizEGLFeZzDbr1r6SjwKYZQEB0Z/trGsdAIsw5EadaR010/zvJ0arkw6vznyTevcMi9BtppprJ5aqLXRg==
+
 nanoid@3.1.20:
   version "3.1.20"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"


### PR DESCRIPTION
[Nano Colors][1] is a very fast and lightweight color formatting library. It is faster than alternatives in both loading and calling times and saves precious space in `node_modules`.

After doing the same operation in cli-ux (see https://github.com/oclif/cli-ux/pull/417) as well as oclif/parser, the overall dependency tree of oclif will be less clunky, and the install size will be smaller.

[1]: ai/nanocolors
