### PR TITLE
fix: only show warnings when json is not enabled

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -176,7 +176,7 @@ export default abstract class Command {
 
   warn(input: string | Error): string | Error {
     if (!this.jsonEnabled()) Errors.warn(input)
-    return input;
+    return input
   }
 
   error(input: string | Error, options: {code?: string; exit: false} & PrettyPrintableError): void

--- a/src/command.ts
+++ b/src/command.ts
@@ -174,8 +174,9 @@ export default abstract class Command {
     return Errors.exit(code)
   }
 
-  warn(input: string | Error): void {
+  warn(input: string | Error): string | Error {
     if (!this.jsonEnabled()) Errors.warn(input)
+    return input;
   }
 
   error(input: string | Error, options: {code?: string; exit: false} & PrettyPrintableError): void

--- a/src/command.ts
+++ b/src/command.ts
@@ -175,7 +175,7 @@ export default abstract class Command {
   }
 
   warn(input: string | Error): void {
-    Errors.warn(input)
+    if (!this.jsonEnabled()) Errors.warn(input)
   }
 
   error(input: string | Error, options: {code?: string; exit: false} & PrettyPrintableError): void


### PR DESCRIPTION
Only print warnings when json is not enabled