### PR TITLE
fix: use default separator if none is configured

### DIFF
--- a/src/help/util.ts
+++ b/src/help/util.ts
@@ -87,7 +87,7 @@ export function toStandardizedId(commandID: string, config: IConfig): string {
 
 export function toConfiguredId(commandID: string, config: IConfig): string {
   const defaultTopicSeperator = ':'
-  return commandID.replace(new RegExp(defaultTopicSeperator, 'g'), config.topicSeparator)
+  return commandID.replace(new RegExp(defaultTopicSeperator, 'g'), config.topicSeparator || defaultTopicSeperator)
 }
 
 export function standardizeIDFromArgv(argv: string[], config: IConfig): string[] {


### PR DESCRIPTION
[skip-validate-pr]