### PR TITLE
fix: remove ability to enable json flag globally

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -1,6 +1,5 @@
 import {fileURLToPath} from 'url'
 
-import {settings} from './settings'
 import {format, inspect} from 'util'
 import {cli} from 'cli-ux'
 import {Config} from './config'
@@ -128,7 +127,7 @@ export default abstract class Command {
   }
 
   static set flags(flags: Interfaces.FlagInput<any>) {
-    this._flags = this.enableJsonFlag || settings.enableJsonFlag ? Object.assign({}, Command.globalFlags, flags) : flags
+    this._flags = this.enableJsonFlag ? Object.assign({}, Command.globalFlags, flags) : flags
   }
 
   id: string | undefined

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -30,10 +30,6 @@ export type Settings = {
    *   NODE_ENV=development
    */
   tsnodeEnabled?: boolean;
-  /**
-   * Enable the --json flag for all commands
-   */
-  enableJsonFlag?: boolean;
 };
 
 // Set global.oclif to the new object if it wasn't set before


### PR DESCRIPTION
Removes the ability to enable the --json flag globally using `settings`.

Using `settings` turned out to be problematic because it's scoped to the executing plugin - in other words, if it's not set at the CLI level, it won't be set at the plugin level. Practically speaking, this is an issue when running `oclif manifest` to generate the manifest since `oclif`'s `settings` will be used in place of the plugin's - meaning that the `--json` flag won't show up in the manifest

For now, I'd like to remove this entirely and wait for users to request the feature. If there's enough demand for it, we can figure out a better way to enable flags globally

@W-9831737@