### PR TITLE
feat: Add support for typescript files and ESModules.

### DIFF
--- a/src/module-loader.ts
+++ b/src/module-loader.ts
@@ -7,13 +7,12 @@ import {Config as IConfig} from './interfaces'
 import {Plugin as IPlugin} from './interfaces'
 import * as Config from './config'
 
-const getPackageType = require('get-package-type')
 
 /**
  * Defines file extension resolution when source files do not have an extension.
  */
 // eslint-disable-next-line camelcase
-const s_EXTENSIONS: string[] = ['.js', '.mjs', '.cjs']
+const s_EXTENSIONS: string[] = ['.js', '.mjs', '.cjs', '.ts']
 
 /**
  * Provides a mechanism to use dynamic import / import() with tsconfig -> module: commonJS as otherwise import() gets
@@ -99,17 +98,18 @@ export default class ModuleLoader {
    * the `modulePath` provided ends in `.mjs` it is assumed to be ESM.
    *
    * @param {string} filePath - File path to test.
+   * @param {IConfig|IPlugin} config - Oclif config or plugin config.
    *
    * @returns {boolean} The modulePath is an ES Module.
    * @see https://www.npmjs.com/package/get-package-type
    */
-  static isPathModule(filePath: string): boolean {
+  static isPathModule(filePath: string, config: IConfig|IPlugin): boolean {
     const extension = path.extname(filePath).toLowerCase()
 
     switch (extension) {
+    case '.ts':
     case '.js':
-      return getPackageType.sync(filePath) === 'module'
-
+      return config.pjson?.type === 'module'
     case '.mjs':
       return true
 
@@ -135,7 +135,7 @@ export default class ModuleLoader {
 
     try {
       filePath = require.resolve(modulePath)
-      isESM = ModuleLoader.isPathModule(filePath)
+      isESM = ModuleLoader.isPathModule(filePath, config)
     } catch {
       filePath = Config.tsPath(config.root, modulePath)
 
@@ -152,7 +152,7 @@ export default class ModuleLoader {
         }
       }
 
-      isESM = ModuleLoader.isPathModule(filePath)
+      isESM = ModuleLoader.isPathModule(filePath, config)
     }
 
     return {isESM, filePath}


### PR DESCRIPTION
When relying on third party dependencies that are [ESModules](https://nodejs.org/api/esm.html#modules-ecmascript-modules) (which is getting more popularity in the Node.js community it is important to be invoked by an ESModule. 

Currently the `@oclif/core` already works when using pure ESModules by setting the `"type": "module"` inside the `package.json`.

But if you want to leverage `typescript` you currently need to compile the typescript sources to the `lib` folder by running `npx tsc --project tsconfig.json`. This will compile the command inside the lib folder. After that running `./bin/run.js` will work.

IMHO this developer experience can be enhanced by leveraging ts-node to directly run the typescript sources.


All that the developer now needs to do is to specify the `ts-node/esm` loader when invoking the binary by updating the binary file with the following content:

The file `bin/run.js`

```javascript
#!/usr/bin/env node --experimental-specifier-resolution=node --no-warnings --loader ts-node/esm
import { Errors, flush, run } from '@oclif/core';

run(void 0, import.meta.url)
  .then(flush)
  .catch(Errors.handle);
```

now it can be invoked by running `NODE_ENV=development ./bin/run.js` and it will use `ts-node` to transpile the modules on the fly and resolve them correctly with this changes.

A better DX as first compiling and then running IMHO.