### PR TITLE
Add missing await to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ class LS extends Command {
   }
 
   async run() {
-    const {flags} = this.parse(LS)
+    const {flags} = await this.parse(LS)
     let files = fs.readdirSync(flags.dir)
     for (let f of files) {
       this.log(f)


### PR DESCRIPTION
Noticed this while migrating to @oclif/core from @oclif/command.