### PR TITLE
chore: reenable integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,19 +19,19 @@ workflows:
                 - lts
                 - maintenance
             alias: unit-tests
-      # - release-management/test-package:
-      #     matrix:
-      #       parameters:
-      #         os:
-      #           - linux
-      #           - windows
-      #         node_version:
-      #           - latest
-      #           - lts
-      #           - maintenance
-      #         command:
-      #           - yarn test:e2e
-      #       alias: integration-tests
+      - release-management/test-package:
+          matrix:
+            parameters:
+              os:
+                - linux
+                - windows
+              node_version:
+                - latest
+                - lts
+                - maintenance
+              command:
+                - yarn test:e2e
+            alias: integration-tests
       - release-management/release-package:
           context: SF-CLI-RELEASE-PROCESS
           filters:
@@ -40,7 +40,7 @@ workflows:
           github-release: true
           requires:
             - unit-tests
-            # - integration-tests
+            - integration-tests
   dependabot-automerge:
     triggers:
       - schedule:

--- a/test/integration/sf.e2e.ts
+++ b/test/integration/sf.e2e.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai'
 import {Executor, setup} from './util'
 
-describe('Salesforce CLI (sf)', () => {
+describe.only('Salesforce CLI (sf)', () => {
   let executor: Executor
   before(async () => {
     executor = await setup(__filename, {repo: 'git@github.com:salesforcecli/cli.git'})
@@ -45,6 +45,7 @@ describe('Salesforce CLI (sf)', () => {
 
   it('should have formatted json success output', async () => {
     const config = await executor.executeCommand('config list --json')
+    console.log(config)
     const result = JSON.parse(config.output!)
     expect(result).to.have.property('status')
     expect(result).to.have.property('result')

--- a/test/integration/sf.e2e.ts
+++ b/test/integration/sf.e2e.ts
@@ -42,4 +42,22 @@ describe('Salesforce CLI (sf)', () => {
     const regex = /^[A-Z].*\n\nUSAGE[\S\s]*\n\nFLAGS[\S\s]*\n\nGLOBAL FLAGS[\S\s]*\n\nDESCRIPTION[\S\s]*\n\nEXAMPLES[\S\s]*\n\nFLAG DESCRIPTIONS[\S\s]*\n\nCONFIGURATION VARIABLES[\S\s]*\n\nENVIRONMENT VARIABLES[\S\s]*$/g
     expect(regex.test(help.output!)).to.be.true
   })
+
+  it('should have formatted json success output', async () => {
+    const config = await executor.executeCommand('config list --json')
+    const result = JSON.parse(config.output!)
+    expect(result).to.have.property('status')
+    expect(result).to.have.property('result')
+    expect(result).to.have.property('warnings')
+  })
+
+  it('should have formatted json error output', async () => {
+    const config = await executor.executeCommand('config set DOES_NOT_EXIST --json')
+    const result = JSON.parse(config.output!)
+    expect(result).to.have.property('status')
+    expect(result).to.have.property('stack')
+    expect(result).to.have.property('name')
+    expect(result).to.have.property('message')
+    expect(result).to.have.property('warnings')
+  })
 })

--- a/test/integration/sf.e2e.ts
+++ b/test/integration/sf.e2e.ts
@@ -1,7 +1,8 @@
+import * as os from 'os'
 import {expect} from 'chai'
 import {Executor, setup} from './util'
 
-describe.only('Salesforce CLI (sf)', () => {
+describe('Salesforce CLI (sf)', () => {
   let executor: Executor
   before(async () => {
     process.env.SFDX_TELEMETRY_DISABLE_ACKNOWLEDGEMENT = 'true'
@@ -42,6 +43,35 @@ describe.only('Salesforce CLI (sf)', () => {
      */
     const regex = /^[A-Z].*\n\nUSAGE[\S\s]*\n\nFLAGS[\S\s]*\n\nGLOBAL FLAGS[\S\s]*\n\nDESCRIPTION[\S\s]*\n\nEXAMPLES[\S\s]*\n\nFLAG DESCRIPTIONS[\S\s]*\n\nCONFIGURATION VARIABLES[\S\s]*\n\nENVIRONMENT VARIABLES[\S\s]*$/g
     expect(regex.test(help.output!)).to.be.true
+  })
+
+  it('should show custom short help', async () => {
+    const help = await executor.executeCommand('deploy metadata -h')
+    /**
+     * Regex matches that the short help output matches this form:
+     *
+     * @example
+     * <summary>
+     *
+     * USAGE
+     *   <usage>
+     *
+     * FLAGS
+     *   <flags>
+     *
+     * GLOBAL FLAGS
+     *   <global flags>
+     */
+    const regex = /^[A-Z].*\n\nUSAGE[\S\s]*\n\nFLAGS[\S\s]*\n\nGLOBAL FLAGS[\S\s]*$/g
+    expect(regex.test(help.output!)).to.be.true
+  })
+
+  it('should show version using -v', async () => {
+    const version = await executor.executeCommand('-v')
+    expect(version.output).to.include('@salesforce/cli')
+    expect(version.output).to.include(process.platform)
+    expect(version.output).to.include(os.arch())
+    expect(version.output).to.include(process.version)
   })
 
   it('should have formatted json success output', async () => {

--- a/test/integration/sf.e2e.ts
+++ b/test/integration/sf.e2e.ts
@@ -4,6 +4,7 @@ import {Executor, setup} from './util'
 describe.only('Salesforce CLI (sf)', () => {
   let executor: Executor
   before(async () => {
+    process.env.SFDX_TELEMETRY_DISABLE_ACKNOWLEDGEMENT = 'true'
     executor = await setup(__filename, {repo: 'git@github.com:salesforcecli/cli.git'})
   })
 
@@ -45,7 +46,6 @@ describe.only('Salesforce CLI (sf)', () => {
 
   it('should have formatted json success output', async () => {
     const config = await executor.executeCommand('config list --json')
-    console.log(config)
     const result = JSON.parse(config.output!)
     expect(result).to.have.property('status')
     expect(result).to.have.property('result')
@@ -60,5 +60,15 @@ describe.only('Salesforce CLI (sf)', () => {
     expect(result).to.have.property('name')
     expect(result).to.have.property('message')
     expect(result).to.have.property('warnings')
+  })
+
+  it('should handle varags', async () => {
+    const config = await executor.executeCommand('config set disableTelemetry=true restDeploy=true --global --json')
+    const parsed = JSON.parse(config.output!)
+    expect(parsed.status).to.equal(0)
+    const results = parsed.result as Array<{success: boolean}>
+    for (const result of results) {
+      expect(result.success).to.be.true
+    }
   })
 })

--- a/test/integration/util.ts
+++ b/test/integration/util.ts
@@ -113,7 +113,7 @@ export async function setup(testFile: string, options: Options): Promise<Executo
     })
   }
 
-  const install = 'yarn'
+  const install = 'yarn install --force'
   console.log(chalk.cyan(`${testFileName}:`), install)
   await executor.executeInTestDir(install)
 


### PR DESCRIPTION
Re-enables integration tests that were temporarily disabled as we debugged the plugin install issue (#340)