### PR TITLE
Fix flags cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ Without the generator, you can create a simple CLI like this:
 #!/usr/bin/env ts-node
 
 import * as fs from 'fs'
-import {Command, flags} from '@oclif/core'
+import {Command, Flags} from '@oclif/core'
 
 class LS extends Command {
   static flags = {
-    version: flags.version(),
-    help: flags.help(),
+    version: Flags.version(),
+    help: Flags.help(),
     // run with --dir= or -d=
-    dir: flags.string({
+    dir: Flags.string({
       char: 'd',
       default: process.cwd(),
     }),
@@ -39,7 +39,7 @@ class LS extends Command {
 
   async run() {
     const {flags} = await this.parse(LS)
-    let files = fs.readdirSync(flags.dir)
+    let files = fs.readdirSync(Flags.dir)
     for (let f of files) {
       this.log(f)
     }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ class LS extends Command {
 
   async run() {
     const {flags} = await this.parse(LS)
-    let files = fs.readdirSync(Flags.dir)
+    let files = fs.readdirSync(flags.dir)
     for (let f of files) {
       this.log(f)
     }


### PR DESCRIPTION
The `Flags` object exported from `@oclif/core` begins with a capital F (in prior versions it was a small `f`)