### PR TITLE
fix: module resolution of linked plugins

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -281,7 +281,13 @@ export class Config implements IConfig {
     debug('runCommand %s %o', id, argv)
     const c = cachedCommand || this.findCommand(id)
     if (!c) {
-      await this.runHook('command_not_found', {id, argv})
+      const hookResult = await this.runHook('command_not_found', {id, argv})
+
+      if (hookResult.successes[0]) {
+        const cmdResult = hookResult.successes[0].result
+        return cmdResult as T
+      }
+
       throw new CLIError(`command ${id} not found`)
     }
 

--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -83,7 +83,7 @@ async function findRoot(name: string | undefined, root: string) {
   if (name) {
     let pkgPath
     try {
-      pkgPath = resolvePackage(name, {paths: [__dirname, root]})
+      pkgPath = resolvePackage(name, {paths: [root]})
     } catch {}
 
     return pkgPath ? findSourcesRoot(path.dirname(pkgPath)) : findRootLegacy(name, root)

--- a/src/interfaces/hooks.ts
+++ b/src/interfaces/hooks.ts
@@ -35,7 +35,7 @@ export interface Hooks {
   };
   'command_not_found': {
     options: {id: string; argv?: string[]};
-    return: void;
+    return: unknown;
   };
   'plugins:preinstall': {
     options: {


### PR DESCRIPTION
- Fixes module resolution for linked plugins
- Fixes issue with `command_not_found` hook always throwing an error - even if the correct command was run by `plugin-not-found`

@W-10501665@