### PR TITLE
feat: add S3Manifest

### DIFF
--- a/src/cli-ux/prompt.ts
+++ b/src/cli-ux/prompt.ts
@@ -1,4 +1,4 @@
-import * as Errors from '../../src/errors'
+import * as Errors from '../errors'
 import * as chalk from 'chalk'
 
 import config from './config'

--- a/src/interfaces/hooks.ts
+++ b/src/interfaces/hooks.ts
@@ -26,11 +26,11 @@ export interface Hooks {
     return: void;
   };
   preupdate: {
-    options: {channel: string};
+    options: {channel: string, version: string};
     return: void;
   };
   update: {
-    options: {channel: string};
+    options: {channel: string, version: string};
     return: void;
   };
   'command_not_found': {

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -5,6 +5,7 @@ export {OclifError, PrettyPrintableError} from './errors'
 export {HelpOptions} from './help'
 export {Hook, Hooks} from './hooks'
 export {Manifest} from './manifest'
+export {S3Manifest} from './s3-manifest'
 export {
   ParserArg, Arg, ParseFn, ParserOutput, ParserInput, ArgToken,
   OptionalArg, FlagOutput, OutputArgs, OutputFlags, FlagUsageOptions,

--- a/src/interfaces/s3-manifest.ts
+++ b/src/interfaces/s3-manifest.ts
@@ -1,0 +1,14 @@
+export interface S3Manifest {
+  version: string;
+  sha: string;
+  gz: string;
+  xz?: string;
+  sha256gz: string;
+  sha256xz?: string;
+  baseDir: string;
+  rollout?: number;
+  node: {
+    compatible: string;
+    recommended: string;
+  };
+}


### PR DESCRIPTION
Adds `S3Manifest` interface which will be used by [oclif](https://github.com/oclif/oclif/blob/main/src/tarballs/config.ts#L33) and [plugin-update](https://github.com/oclif/plugin-update/blob/main/src/update.ts#L4).

The main motivation for doing this is so that plugin-update doesn't have to depend on oclif - which should reduce it's size considerably