### PR TITLE
Fix: Command parsing hangs under unit test

### DIFF
--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -23,7 +23,7 @@ try {
 const readStdin = async () => {
   const {stdin} = process
   let result
-  if (stdin.isTTY) return result
+  if (stdin.isTTY || stdin.isTTY === undefined) return result
   result = ''
   stdin.setEncoding('utf8')
   for await (const chunk of stdin) {


### PR DESCRIPTION
I believe that this addresses issue https://github.com/oclif/core/issues/330

Under test, the `process.stdin.isTTY` property isn't properly inherited (possibly related to this: https://stackoverflow.com/a/68260765) meaning that rather than bailing out immediately, the `readStdin` function hangs indefinitely waiting for input to be provided.