### PR TITLE
fix: update isProd utility

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -37,5 +37,5 @@ export function castArray<T>(input?: T | T[]): T[] {
 }
 
 export function isProd() {
-  return process.env.NODE_ENV !== 'development'
+  return !['development', 'test'].includes(process.env.NODE_ENV ?? '')
 }


### PR DESCRIPTION
`isProd` returns false if `process.env.NODE_ENV` is either `development` or `test`

Fixes #367