### PR TITLE
feat: make global flags settable

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -21,6 +21,13 @@ process.stdout.on('error', (err: any) => {
   throw err
 })
 
+const jsonFlag = {
+  json: Flags.boolean({
+    description: 'Format output as json.',
+    helpGroup: 'GLOBAL',
+  }),
+}
+
 /**
  * An abstract class which acts as the base for each command
  * in your project.
@@ -112,22 +119,28 @@ export default abstract class Command {
     return cmd._run(argv)
   }
 
-  private static globalFlags = {
-    json: Flags.boolean({
-      description: 'Format output as json.',
-      helpGroup: 'GLOBAL',
-    }),
+  protected static _globalFlags = {}
+
+  static get globalFlags(): Interfaces.FlagInput<any> {
+    return this._globalFlags
+  }
+
+  static set globalFlags(flags: Interfaces.FlagInput<any>) {
+    this._globalFlags = this.enableJsonFlag ?
+      Object.assign({}, jsonFlag, this.globalFlags, flags) :
+      Object.assign({}, this.globalFlags, flags)
   }
 
   /** A hash of flags for the command */
-  private static _flags: Interfaces.FlagInput<any>
+  protected static _flags: Interfaces.FlagInput<any>
 
   static get flags(): Interfaces.FlagInput<any> {
     return this._flags
   }
 
   static set flags(flags: Interfaces.FlagInput<any>) {
-    this._flags = this.enableJsonFlag ? Object.assign({}, Command.globalFlags, flags) : flags
+    this.globalFlags = {}
+    this._flags = Object.assign({}, this.globalFlags, flags)
   }
 
   id: string | undefined

--- a/src/command.ts
+++ b/src/command.ts
@@ -119,7 +119,7 @@ export default abstract class Command {
     return cmd._run(argv)
   }
 
-  protected static _globalFlags = {}
+  protected static _globalFlags: Interfaces.FlagInput<any>
 
   static get globalFlags(): Interfaces.FlagInput<any> {
     return this._globalFlags


### PR DESCRIPTION
Makes it so that global flags are settable. This allows users to have a base command class that defines flags that should be inherited by all child instances.

```typescript
export abstract class MyBaseCommand extends Command {
  public static globalFlags = {
    interactive: Flags.boolean({
      description: 'Interactive Command Completion',
      default: false,
      helpGroup: 'GLOBAL',
    }),
  };
}
```

This was possible before but it required a lot of unpleasant code:

```typescript
export abstract class MyBaseCommand extends Command {
  private static specialFlags = {
    interactive: Flags.boolean({
      description: 'Interactive Command Completion',
      default: false,
      helpGroup: 'GLOBAL',
    }),
  };

  // eslint-disable-next-line @typescript-eslint/no-explicit-any
  public static get flags(): Interfaces.FlagInput<any> {
    // @ts-expect-error because private member
    // eslint-disable-next-line @typescript-eslint/no-explicit-any
    return this._flags as Interfaces.FlagInput<any>;
  }

  // eslint-disable-next-line @typescript-eslint/no-explicit-any
  public static set flags(flags: Interfaces.FlagInput<any>) {
    // @ts-expect-error because private member
    // eslint-disable-next-line @typescript-eslint/no-explicit-any
    this._flags = Object.assign({}, super.globalFlags, MyBaseCommand.specialFlags, flags) as Interfaces.FlagInput<any>;
  }
}
```