### PR TITLE
fix bug where custom flags do not respect multiple option

### DIFF
--- a/src/parser/flags.ts
+++ b/src/parser/flags.ts
@@ -18,7 +18,7 @@ export function build<T>(defaults: Partial<OptionFlag<T>>): Definition<T> {
       ...defaults,
       ...options,
       input: [] as string[],
-      multiple: Boolean(options.multiple),
+      multiple: Boolean(options.multiple === undefined ? defaults.multiple : options.multiple),
       type: 'option',
     } as any
   }

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -327,6 +327,14 @@ See more help with --help`)
         expect(out.flags.baz.toUpperCase()).to.equal('D')
         expect(out.flags.bar.join('|')).to.equal('a|b')
       })
+      it('parses multiple flags on custom flags', async () => {
+        const out = await parse(['--foo', 'a', '--foo=b'], {
+          flags: {
+            foo: flags.option({multiple: true, parse: async i => i}),
+          },
+        })
+        expect(out.flags).to.deep.include({foo: ['a', 'b']})
+      })
     })
 
     describe('strict: false', () => {


### PR DESCRIPTION
Currently, custom flags do not honor the `multiple` option. This fixes the issue by only overriding the `multiple` default if explicitly provided in `options`.