### PR TITLE
fix: improve algo for collating command id

### DIFF
--- a/test/help/util.test.ts
+++ b/test/help/util.test.ts
@@ -67,6 +67,19 @@ describe('util', () => {
 
     test
     .stub(Config.prototype, 'collectUsableIds', () => ['foo', 'foo:bar'])
+    .it('should return standardized id when topic separator is a space and has args and command is misspelled', () => {
+      config.topicSeparator = ' '
+      // @ts-expect-error private member
+      config._commands.set('foo:bar', {
+        id: 'foo:bar',
+        args: [{name: 'first'}],
+      })
+      const actual = standardizeIDFromArgv(['foo', 'ba', 'baz'], config)
+      expect(actual).to.deep.equal(['foo:ba:baz'])
+    })
+
+    test
+    .stub(Config.prototype, 'collectUsableIds', () => ['foo', 'foo:bar'])
     .it('should return standardized id when topic separator is a space and has args', () => {
       config.topicSeparator = ' '
       // @ts-expect-error private member


### PR DESCRIPTION
Improve the function used for deciphering the command id from the `argv`. 

This improves the experience when executing commands with args in flexible taxonomy mode.

[skip-validate-pr]