### PR TITLE
fix: support CLIs with single top level command

### DIFF
--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -192,7 +192,8 @@ export class Plugin implements IPlugin {
       const p = path.parse(file)
       const topics = p.dir.split('/')
       const command = p.name !== 'index' && p.name
-      return [...topics, command].filter(f => f).join(':')
+      const id = [...topics, command].filter(f => f).join(':')
+      return id === '' ? '.' : id
     })
     this._debug('found commands', ids)
     return ids


### PR DESCRIPTION
Support CLIs with a single top level command (i.e. the executable is the only command).

With this fix, users will need to do two things:
1. Place their command at the top level of the `commands` dir, e.g. `src/commands/index.ts`
2. supply the `default` in their oclif config, for example

```
oclif: {
  default: ".",
  commands: "./dist/commands"
}
```

Fixes #425 