### PR TITLE
feat: improve the instantiation of global flags

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -104,7 +104,7 @@ export default abstract class Command {
 
   static set enableJsonFlag(value: boolean) {
     this._enableJsonFlag = value
-    this.globalFlags = jsonFlag
+    if (value) this.globalFlags = jsonFlag
   }
 
   // eslint-disable-next-line valid-jsdoc

--- a/src/command.ts
+++ b/src/command.ts
@@ -96,7 +96,16 @@ export default abstract class Command {
 
   static parserOptions = {}
 
-  static enableJsonFlag = false
+  static _enableJsonFlag = false
+
+  static get enableJsonFlag(): boolean {
+    return this._enableJsonFlag
+  }
+
+  static set enableJsonFlag(value: boolean) {
+    this._enableJsonFlag = value
+    this.globalFlags = jsonFlag
+  }
 
   // eslint-disable-next-line valid-jsdoc
   /**
@@ -126,9 +135,8 @@ export default abstract class Command {
   }
 
   static set globalFlags(flags: Interfaces.FlagInput<any>) {
-    this._globalFlags = this.enableJsonFlag ?
-      Object.assign({}, jsonFlag, this.globalFlags, flags) :
-      Object.assign({}, this.globalFlags, flags)
+    this._globalFlags = Object.assign({}, this.globalFlags, flags)
+    this.flags = this.globalFlags
   }
 
   /** A hash of flags for the command */
@@ -139,7 +147,6 @@ export default abstract class Command {
   }
 
   static set flags(flags: Interfaces.FlagInput<any>) {
-    this.globalFlags = {}
     this._flags = Object.assign({}, this.globalFlags, flags)
   }
 
@@ -239,7 +246,7 @@ export default abstract class Command {
     if (!options) options = this.constructor as any
     const opts = {context: this, ...options}
     // the spread operator doesn't work with getters so we have to manually add it here
-    opts.flags = options?.flags
+    opts.flags = Object.assign({}, options?.flags, options?.globalFlags)
     return Parser.parse(argv, opts)
   }
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -104,7 +104,7 @@ export default abstract class Command {
 
   static set enableJsonFlag(value: boolean) {
     this._enableJsonFlag = value
-    if (value) this.globalFlags = jsonFlag
+    if (Boolean(value)) this.globalFlags = jsonFlag
   }
 
   // eslint-disable-next-line valid-jsdoc

--- a/src/command.ts
+++ b/src/command.ts
@@ -104,7 +104,7 @@ export default abstract class Command {
 
   static set enableJsonFlag(value: boolean) {
     this._enableJsonFlag = value
-    if (Boolean(value)) this.globalFlags = jsonFlag
+    if (value) this.globalFlags = jsonFlag
   }
 
   // eslint-disable-next-line valid-jsdoc

--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -164,6 +164,7 @@ export type Flag<T> = BooleanFlag<T> | OptionFlag<T>
 
 export type Input<TFlags extends FlagOutput> = {
   flags?: FlagInput<TFlags>;
+  globalFlags?: FlagInput<TFlags>;
   args?: ArgInput;
   strict?: boolean;
   context?: any;


### PR DESCRIPTION
Removes the need to instantiate `flags` in order for `globalFlags` to be recognized

#### Before

```typescript
import {Command, Flags} from '@oclif/core'

export abstract class BaseCommand extends Command {
  static _globalFlags = {
    config: Flags.string({
      description: 'Specify config file',
    }),
  };

  static flags = {}; // NOTE: Required otherwise _globalFlags is ignored.
}
```

#### After

```typescript
import {Command, Flags} from '@oclif/core'

export abstract class BaseCommand extends Command {
  static _globalFlags = {
    config: Flags.string({
      description: 'Specify config file',
    }),
  };
}
```

Fixes #444 
