### PR TITLE
fix: flush not hitting drain condition

### DIFF
--- a/src/cli-ux/index.ts
+++ b/src/cli-ux/index.ts
@@ -22,9 +22,12 @@ function timeout(p: Promise<any>, ms: number) {
 }
 
 async function flush() {
-  const p = new Promise(resolve => process.stdout.once('drain', () => resolve(null)))
+  const p = new Promise(resolve => {
+    process.stdout.once('drain', () => resolve(null))
+  })
   const flushed = process.stdout.write('')
-  if(flushed) {
+
+  if (flushed) {
     return Promise.resolve()
   }
   return p

--- a/src/cli-ux/index.ts
+++ b/src/cli-ux/index.ts
@@ -22,10 +22,11 @@ function timeout(p: Promise<any>, ms: number) {
 }
 
 async function flush() {
-  const p = new Promise(resolve => {
-    process.stdout.once('drain', () => resolve(null))
-  })
-  process.stdout.write('')
+  const p = new Promise(resolve => process.stdout.once('drain', () => resolve(null)))
+  const flushed = process.stdout.write('')
+  if(flushed) {
+    return Promise.resolve()
+  }
   return p
 }
 

--- a/src/cli-ux/index.ts
+++ b/src/cli-ux/index.ts
@@ -30,6 +30,7 @@ async function flush() {
   if (flushed) {
     return Promise.resolve()
   }
+
   return p
 }
 


### PR DESCRIPTION
This fixes the flush function never resolving, `process.stdout.write('')` will return true if the writing chunk was accepted, only if it returns false we'll need to listen to the drain event.

More info on the Stream documentation -> https://nodejs.org/docs/latest-v14.x/api/stream.html#stream_writable_write_chunk_encoding_callback 