### PR TITLE
fix: throw appropriate error in runCommand

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -335,6 +335,10 @@ export class Config implements IConfig {
         return cmdResult as T
       }
 
+      if (hookResult.failures[0]) {
+        throw hookResult.failures[0].error
+      }
+
       throw new CLIError(`command ${id} not found`)
     }
 


### PR DESCRIPTION
Throw the right error when a command is run by the `command_incomplete` hook and fails