### PR TITLE
fix: improve flag types

### DIFF
--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -201,4 +201,5 @@ export type CompletableOptionFlag<T> = OptionFlag<T> & {
 
 export type CompletableFlag<T> = BooleanFlag<T> | CompletableOptionFlag<T>
 
-export type FlagInput<T extends FlagOutput = {[flag: string]: unknown}> = { [P in keyof T]: CompletableFlag<T[P]> }
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type FlagInput<T extends FlagOutput = object> = { [P in keyof T]: CompletableFlag<T[P]> }


### PR DESCRIPTION
Because of how `globalFlags` is typed, if you **do not** define any global flags then the `flags` returned from `Command.parse` will include `{ [flag: string]: unknown }`, which prevents typescript from erroring when you're attempting to access a non-existent flag.

This PR changes the default type for `flags` and `globalFlags` from `{ [flag: string]: unknown }` to `object`. Doing so removes the index signature and allows typescript to fail when accessing a non-existent flag. Unfortunately, this requires using the `object` type which is [discouraged](https://github.com/typescript-eslint/typescript-eslint/blob/v4.31.2/packages/eslint-plugin/docs/rules/ban-types.md).

The alternative to this wrapping the returned flags in a new generic type that removes the index signature,

```typescript
type Knowable<T> = {
   [ K in keyof T as string extends K ? never : number extends K ? never : K ] : T[K]
};
```

This also solves the problem but it slightly obscures what the actual flags are, e.g.

![Screen Shot 2022-08-05 at 1 17 48 PM](https://user-images.githubusercontent.com/10244328/183146088-20a406da-7703-483b-a578-471af0ebac0a.png)



