### PR TITLE
fix: skip loadDevPlugins

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -219,13 +219,15 @@ export class Config implements IConfig {
   }
 
   async loadDevPlugins() {
-    // do not load oclif.devPlugins in production
-    if (this.isProd) return
-    try {
-      const devPlugins = this.pjson.oclif.devPlugins
-      if (devPlugins) await this.loadPlugins(this.root, 'dev', devPlugins)
-    } catch (error: any) {
-      process.emitWarning(error)
+    if (this.options.devPlugins !== false) {
+      // do not load oclif.devPlugins in production
+      if (this.isProd) return
+      try {
+        const devPlugins = this.pjson.oclif.devPlugins
+        if (devPlugins) await this.loadPlugins(this.root, 'dev', devPlugins)
+      } catch (error: any) {
+        process.emitWarning(error)
+      }
     }
   }
 


### PR DESCRIPTION
restore old `@oclif/config` behaviour 
(see: https://github.com/oclif/config/blob/b1ff958d5f017f2321eb7d2efa98bb6e61e1c513/src/config.ts#L277) because 
`oclif readme` calls `await Config.load({root: cwd, devPlugins: false, userPlugins: false})`
(see https://github.com/oclif/oclif/blob/f80dcfcad472205e3c15078fa0f937489d1833c6/src/commands/readme.ts#L41) 
with `devPlugins: false` to skip `loadDevPlugins()` and exclude devPlugins in the created readme file.

