### PR TITLE
allow custom timeouts for ux flush

### DIFF
--- a/src/cli-ux/index.ts
+++ b/src/cli-ux/index.ts
@@ -128,8 +128,8 @@ export const ux = {
     }
   },
 
-  async flush() {
-    await timeout(flush(), 10_000)
+  async flush(ms = 10_000) {
+    await timeout(flush(), ms)
   },
 }
 


### PR DESCRIPTION
Sorry for not just creating PR to start. This addresses #464.
Some of commands are timing out when using the cli-ux flush implementation, this makes it easy to increase the timeouts for some folks (like me).