### PR TITLE
fix: revert #460

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -104,14 +104,7 @@ export default abstract class Command {
 
   static set enableJsonFlag(value: boolean) {
     this._enableJsonFlag = value
-    if (value === true) {
-      this.globalFlags = jsonFlag
-    } else {
-      // @ts-ignore
-      delete this.globalFlags.json
-      // @ts-ignore
-      delete this.flags.json
-    }
+    if (value) this.globalFlags = jsonFlag
   }
 
   // eslint-disable-next-line valid-jsdoc


### PR DESCRIPTION
Reverts the change made in #460 

The fix does not work when:

1. Base `Command` class sets `enableJsonFlag = true`
2. There are multiple subclasses, one of which sets `enableJsonFlag = false`

In that scenario all subclasses will have the json flag disabled instead of just the one. 

This bug is currently affecting plugin-deploy-retrieve so I think we should revert this for now so that we can take our time coming up with a more thorough solution