### PR TITLE
fix: parser doesn't validate against options parameter if the value is provided through an env var

### DIFF
--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -790,6 +790,28 @@ See more help with --help`)
 
       expect(message).to.equal('Expected --foo=invalidopt to be one of: myopt, myotheropt\nSee more help with --help')
     })
+    it('fails when invalid env var', async () => {
+      let message = ''
+      process.env.TEST_FOO = 'invalidopt'
+      try {
+        await parse([], {
+          flags: {foo: flags.string({options: ['myopt', 'myotheropt'], env: 'TEST_FOO'})},
+        })
+      } catch (error: any) {
+        message = error.message
+      }
+
+      expect(message).to.equal('Expected --foo=invalidopt to be one of: myopt, myotheropt\nSee more help with --help')
+    })
+
+    it('accepts valid option env var', async () => {
+      process.env.TEST_FOO = 'myopt'
+
+      const out = await parse([], {
+        flags: {foo: flags.string({options: ['myopt', 'myotheropt'], env: 'TEST_FOO'})},
+      })
+      expect(out.flags.foo).to.equal('myopt')
+    })
   })
 
   describe('url flag', () => {


### PR DESCRIPTION
Hey, I found this issue that when I try to pass a flag as an environment variable it is not validated if this value is on the options field.

An example would be

```javascript
export default class MyCommand extends Command {
  static flags = {
    foo: Flags.string({
      env: 'FOO',
      options: ['valid1', 'valid2']
    })
  }
}
```

My understanding here is that if I execute the command with the `FOO` environment variable as `invalid` the parsing should fail and an error message should be displayed, this is not happening.

I added a couple of tests that verify this behavior and fixed it on this PR.
