### PR TITLE
fix: isProd checks if manifest exists instead of `NODE_ENV` env var.

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -24,6 +24,15 @@ function channelFromVersion(version: string) {
   return (m && m[1]) || 'stable'
 }
 
+function hasManifest(p: string): boolean {
+  try {
+    require(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
 const WSL = require('is-wsl')
 
 function isConfig(o: any): o is IConfig {
@@ -221,7 +230,7 @@ export class Config implements IConfig {
   async loadDevPlugins() {
     if (this.options.devPlugins !== false) {
       // do not load oclif.devPlugins in production
-      if (this.isProd) return
+      if (hasManifest(path.join(this.root, 'oclif.manifest.json'))) return
       try {
         const devPlugins = this.pjson.oclif.devPlugins
         if (devPlugins) await this.loadPlugins(this.root, 'dev', devPlugins)

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -24,15 +24,6 @@ function channelFromVersion(version: string) {
   return (m && m[1]) || 'stable'
 }
 
-function hasManifest(p: string): boolean {
-  try {
-    require(p)
-    return true
-  } catch {
-    return false
-  }
-}
-
 const WSL = require('is-wsl')
 
 function isConfig(o: any): o is IConfig {
@@ -230,7 +221,7 @@ export class Config implements IConfig {
   async loadDevPlugins() {
     if (this.options.devPlugins !== false) {
       // do not load oclif.devPlugins in production
-      if (hasManifest(path.join(this.root, 'oclif.manifest.json'))) return
+      if (this.isProd) return
       try {
         const devPlugins = this.pjson.oclif.devPlugins
         if (devPlugins) await this.loadPlugins(this.root, 'dev', devPlugins)
@@ -598,7 +589,7 @@ export class Config implements IConfig {
   }
 
   protected get isProd() {
-    return isProd()
+    return isProd(this.root)
   }
 
   private getCmdLookupId(id: string): string {

--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -144,7 +144,7 @@ export class Plugin implements IPlugin {
     this.alias = this.options.name ?? this.pjson.name
     const pjsonPath = path.join(root, 'package.json')
     if (!this.name) throw new Error(`no name in ${pjsonPath}`)
-    if (!isProd() && !this.pjson.files) this.warn(`files attribute must be specified in ${pjsonPath}`)
+    if (!isProd(this.root) && !this.pjson.files) this.warn(`files attribute must be specified in ${pjsonPath}`)
     // eslint-disable-next-line new-cap
     this._debug = Debug(this.name)
     this.version = this.pjson.version

--- a/src/config/ts-node.ts
+++ b/src/config/ts-node.ts
@@ -49,7 +49,7 @@ export function tsPath(root: string, orig: string | undefined): string | undefin
     // the CLI specifically turned it off
     (settings.tsnodeEnabled === false) ||
     // the CLI didn't specify ts-node and it is production
-    (settings.tsnodeEnabled === undefined && isProd())
+    (settings.tsnodeEnabled === undefined && isProd(root))
 
   if (skipTSNode) return orig
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,4 @@
+import {join} from 'path'
 export function compact<T>(a: (T | undefined)[]): T[] {
   return a.filter((a): a is T => Boolean(a))
 }
@@ -36,8 +37,17 @@ export function castArray<T>(input?: T | T[]): T[] {
   return Array.isArray(input) ? input : [input]
 }
 
-export function isProd() {
-  return !['development', 'test'].includes(process.env.NODE_ENV ?? '')
+function hasManifest(path: string): boolean {
+  try {
+    require(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function isProd(root: string) {
+  return hasManifest(join(root, 'oclif.manifest.json'))
 }
 
 export function maxBy<T>(arr: T[], fn: (i: T) => number): T | undefined {

--- a/test/config/config.flexible.test.ts
+++ b/test/config/config.flexible.test.ts
@@ -129,7 +129,7 @@ describe('Config with flexible taxonomy', () => {
     const plugins: IPlugin[] = [pluginA, pluginB]
 
     test = test.add('config', async () => {
-      const config = await Config.load()
+      const config = await Config.load({root: '', devPlugins: false})
       config.flexibleTaxonomy = true
       config.plugins = plugins
       config.pjson.oclif.plugins = ['@My/pluginb', '@My/plugina']


### PR DESCRIPTION
Restores old oclif/config behaviour:
https://github.com/oclif/config/blob/main/src/config.ts#L280

### before
oclif would try to load devPlugins if `NODE_ENV=development|test`, this seems correct but prod CLIs don't ship devDeps so trying to load devPlugins makes oclif emit warns like this:
```
NODE_ENV=development sfdx
(node:15374) Error Plugin: sfdx-cli: could not find package.json with {
  type: 'dev',
  root: '/usr/local/lib/sfdx',
  name: '@oclif/plugin-command-snapshot'
}
module: @oclif/core@1.13.10
task: loadPlugins
plugin: sfdx-cli
root: /usr/local/lib/sfdx
See more details with DEBUG=*
(Use `node --trace-warnings ...` to show where the warning was created)
(node:15374) Error Plugin: sfdx-cli: could not find package.json with {
  type: 'dev',
  root: '/usr/local/lib/sfdx',
  name: '@salesforce/plugin-release-management'
}
```

### after
oclif will load devPlugins if a manifest is present at the root CLI dir.