### PR TITLE
only output help for subcommands, no aliases

### DIFF
--- a/src/help/index.ts
+++ b/src/help/index.ts
@@ -155,7 +155,12 @@ export class Help extends HelpBase {
     }
 
     if (subCommands.length > 0) {
-      this.log(this.formatCommands(subCommands))
+      const aliases:string[] = []
+      const uniqueSubCommands:Interfaces.Command.Loadable[] = subCommands.filter(p => {
+        aliases.push(...p.aliases)
+        return !aliases.includes(p.id)
+      })
+      this.log(this.formatCommands(uniqueSubCommands))
       this.log('')
     }
   }


### PR DESCRIPTION
We have commands with a lot aliases, lately this means help text looks like this:
```
bin/run app add --help
...
COMMANDS
  app add action      Add new actions
  app add actions     Add new actions
  app add event       Add a new Adobe I/O Events action
  app add events      Add a new Adobe I/O Events action
  app add ext         Add new extensions or a standalone application to the project
  app add extension   Add new extensions or a standalone application to the project
  app add extensions  Add new extensions or a standalone application to the project
  app add service     Subscribe to Services in the current Workspace
  app add services    Subscribe to Services in the current Workspace
```

with this pr, it looks like:
```
COMMANDS
  app add action      Add new actions
  app add event       Add a new Adobe I/O Events action
  app add extension   Add new extensions or a standalone application to the project
  app add service     Subscribe to Services in the current Workspace
```

This is currently a draft because I was able to add/change this code without breaking any tests, so likely we are missing some tests for help output.
