### PR TITLE
Paves the way for deno oclif packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "indent-string": "^4.0.0",
     "is-wsl": "^2.2.0",
     "js-yaml": "^3.14.1",
+    "json5": "^2.2.1",
     "natural-orderby": "^2.0.3",
     "object-treeify": "^1.1.33",
     "password-prompt": "^1.1.2",

--- a/src/config/util.ts
+++ b/src/config/util.ts
@@ -1,4 +1,6 @@
 import * as fs from 'fs'
+import * as path from 'path'
+import * as JSON5 from 'json5'
 
 const debug = require('debug')
 
@@ -23,13 +25,16 @@ export function resolvePackage(id: string, paths: { paths: string[] }): string {
   return require.resolve(id, paths)
 }
 
-export function loadJSON(path: string): Promise<any> {
+export function loadJSON(_path: string): Promise<any> {
   debug('config')('loadJSON %s', path)
+  // Allows reading JSON with comments
+  const _JSON = path.extname(_path) === '.jsonc' ? JSON5 : JSON
   return new Promise((resolve, reject) => {
-    fs.readFile(path, 'utf8', (err: any, d: any) => {
+    fs.readFile(_path, 'utf8', (err: any, d: any) => {
       try {
         if (err) reject(err)
-        else resolve(JSON.parse(d))
+        const obj = _JSON.parse(d)
+        resolve(obj)
       } catch (error: any) {
         reject(error)
       }

--- a/src/interfaces/pjson.ts
+++ b/src/interfaces/pjson.ts
@@ -36,6 +36,10 @@ export namespace PJSON {
           version?: string;
           targets?: string[];
         };
+        deno?: {
+          version?: string;
+          targets?: string[];
+        };
       };
       topics?: {
         [k: string]: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2249,6 +2249,11 @@ json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+json5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
+  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"


### PR DESCRIPTION
Tackles the `oclif/core` https://github.com/oclif/core/issues/503.

It paves the way to start supporting deno projects. It essentially extends the logic around using the `package.json` as the project's root config file to also support Deno's `deno.jsonc` configuration file.