### PR TITLE
the spread operator doesn't work with getters so we have to manually add it here (same for args)

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -253,6 +253,7 @@ export default abstract class Command {
     const opts = {context: this, ...options}
     // the spread operator doesn't work with getters so we have to manually add it here
     opts.flags = options?.flags
+    opts.args = options?.args
     return Parser.parse(argv, opts)
   }
 


### PR DESCRIPTION
…
fix bug when using tsyringe `@autoInjectable()` decorator the parser cannot read args from class

there 2 fixes for the issue, the first in the this PR and the second to pass args manually
```
const { args, flags } = await this.parse({...Connect, args: Connect.args });
```

maybe the fix is related to  #603