### PR TITLE
fix: stop inserting extra line breaks in description

### DIFF
--- a/src/help/command.ts
+++ b/src/help/command.ts
@@ -156,20 +156,18 @@ export class CommandHelp extends HelpFormatter {
     const cmd = this.command
 
     let description: string[] | undefined
-
     if (this.opts.hideCommandSummaryInDescription) {
       description = (cmd.description || '').split(POSSIBLE_LINE_FEED).slice(1)
     } else if (cmd.description) {
-      description = [
-        ...(cmd.summary || '').split(POSSIBLE_LINE_FEED),
+      const summary = cmd.summary ? `${cmd.summary}\n` : null
+      description = summary ? [
+        ...summary.split(POSSIBLE_LINE_FEED),
         ...(cmd.description || '').split(POSSIBLE_LINE_FEED),
-      ]
+      ] : (cmd.description || '').split(POSSIBLE_LINE_FEED)
     }
 
     if (description) {
-      // Lines separated with only one newline or more than 2 can be hard to read in the terminal.
-      // Always separate by two newlines.
-      return this.wrap(compact(description).join('\n\n'))
+      return this.wrap(description.join('\n'))
     }
   }
 


### PR DESCRIPTION
Stops inserting extra line breaks into description

Fixes #518 
@W-11894064@