### PR TITLE
feat: support JIT plugin installation

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -341,8 +341,17 @@ export class Config implements IConfig {
       throw new CLIError(`command ${id} not found`)
     }
 
-    if (this.pjson.oclif.jitPlugins?.includes(c.pluginName ?? '') && !this.plugins.find(p => p.name === c?.pluginName)) {
-      const jitResult = await this.runHook('jit_plugin_not_installed', {id, argv, command: c})
+    // console.log(this.pjson.oclif.jitPlugins)
+    if (Object.keys(this.pjson.oclif.jitPlugins ?? {}).includes(c.pluginName ?? '') && !this.plugins.find(p => p.name === c?.pluginName)) {
+      const pluginName = c.pluginName!
+      const pluginVersion = this.pjson.oclif.jitPlugins![pluginName]
+      const jitResult = await this.runHook('jit_plugin_not_installed', {
+        id,
+        argv,
+        command: c,
+        pluginName,
+        pluginVersion,
+      })
       if (jitResult.failures[0]) throw jitResult.failures[0].error
       if (jitResult.successes[0]) {
         await this.loadPluginsAndCommands()
@@ -835,7 +844,7 @@ export async function toCached(c: Command.Class, plugin?: IPlugin): Promise<Comm
   }
 
   // do not include these properties in manifest
-  const ignoreCommandProperties = ['plugin', '_flags']
+  const ignoreCommandProperties = ['plugin', '_flags', '_enableJsonFlag', '_globalFlags']
   const stdKeys = Object.keys(stdProperties)
   const keysToAdd = Object.keys(c).filter(property => ![...stdKeys, ...ignoreCommandProperties].includes(property))
   const additionalProperties: any = {}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -200,6 +200,12 @@ export class Config implements IConfig {
       },
     }
 
+    await this.loadPluginsAndCommands()
+
+    debug('config done')
+  }
+
+  async loadPluginsAndCommands() {
     await this.loadUserPlugins()
     await this.loadDevPlugins()
     await this.loadCorePlugins()
@@ -208,8 +214,6 @@ export class Config implements IConfig {
       this.loadCommands(plugin)
       this.loadTopics(plugin)
     }
-
-    debug('config done')
   }
 
   async loadCorePlugins() {
@@ -325,29 +329,37 @@ export class Config implements IConfig {
   // eslint-disable-next-line default-param-last
   async runCommand<T = unknown>(id: string, argv: string[] = [], cachedCommand?: Command.Loadable): Promise<T> {
     debug('runCommand %s %o', id, argv)
-    const c = cachedCommand || this.findCommand(id)
+    let c = cachedCommand || this.findCommand(id)
     if (!c) {
       const matches = this.flexibleTaxonomy ? this.findMatches(id, argv) : []
       const hookResult = this.flexibleTaxonomy && matches.length > 0 ?
         await this.runHook('command_incomplete', {id, argv, matches}) :
         await this.runHook('command_not_found', {id, argv})
 
-      if (hookResult.successes[0]) {
-        const cmdResult = hookResult.successes[0].result
-        return cmdResult as T
-      }
-
-      if (hookResult.failures[0]) {
-        throw hookResult.failures[0].error
-      }
-
+      if (hookResult.successes[0]) return hookResult.successes[0].result as T
+      if (hookResult.failures[0]) throw hookResult.failures[0].error
       throw new CLIError(`command ${id} not found`)
+    }
+
+    if (this.pjson.oclif.jitPlugins?.includes(c.pluginName ?? '') && !this.plugins.find(p => p.name === c?.pluginName)) {
+      const jitResult = await this.runHook('jit_plugin_not_installed', {id, argv, command: c})
+      if (jitResult.failures[0]) throw jitResult.failures[0].error
+      if (jitResult.successes[0]) {
+        await this.loadPluginsAndCommands()
+        c = this.findCommand(id) ?? c
+      } else {
+        // this means that no jit_plugin_not_installed hook exists, so we should run the default behavior
+        const result = await this.runHook('command_not_found', {id, argv})
+        if (result.successes[0]) return result.successes[0].result as T
+        if (result.failures[0]) throw result.failures[0].error
+        throw new CLIError(`command ${id} not found`)
+      }
     }
 
     const command = await c.load()
     await this.runHook('prerun', {Command: command, argv})
     const result = (await command.run(argv, this)) as T
-    await this.runHook('postrun', {Command: command, result: result, argv})
+    await this.runHook('postrun', {Command: command, result, argv})
     return result
   }
 
@@ -703,6 +715,16 @@ export class Config implements IConfig {
 
       // if a is a core plugin and b is not sort a first
       if (a.pluginType === 'core' && b.pluginType !== 'core') {
+        return -1
+      }
+
+      // if a is a jit plugin and b is not sort b first
+      if (a.pluginType === 'jit' && b.pluginType !== 'jit') {
+        return 1
+      }
+
+      // if b is a jit plugin and a is not sort a first
+      if (b.pluginType === 'jit' && a.pluginType !== 'jit') {
         return -1
       }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -341,8 +341,7 @@ export class Config implements IConfig {
       throw new CLIError(`command ${id} not found`)
     }
 
-    // console.log(this.pjson.oclif.jitPlugins)
-    if (Object.keys(this.pjson.oclif.jitPlugins ?? {}).includes(c.pluginName ?? '') && !this.plugins.find(p => p.name === c?.pluginName)) {
+    if (this.isJitPluginCommand(c)) {
       const pluginName = c.pluginName!
       const pluginVersion = this.pjson.oclif.jitPlugins![pluginName]
       const jitResult = await this.runHook('jit_plugin_not_installed', {
@@ -611,6 +610,10 @@ export class Config implements IConfig {
 
   protected get isProd() {
     return isProd()
+  }
+
+  private isJitPluginCommand(c: Command.Loadable): boolean {
+    return Object.keys(this.pjson.oclif.jitPlugins ?? {}).includes(c.pluginName ?? '') && !this.plugins.find(p => p.name === c?.pluginName)
   }
 
   private getCmdLookupId(id: string): string {

--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -114,8 +114,6 @@ export class Plugin implements IPlugin {
 
   commands!: Command.Loadable[]
 
-  // jitCommands!: Command.Loadable[]
-
   hooks!: {[k: string]: string[]}
 
   valid = false

--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -114,6 +114,8 @@ export class Plugin implements IPlugin {
 
   commands!: Command.Loadable[]
 
+  // jitCommands!: Command.Loadable[]
+
   hooks!: {[k: string]: string[]}
 
   valid = false
@@ -159,7 +161,12 @@ export class Plugin implements IPlugin {
     this.manifest = await this._manifest(Boolean(this.options.ignoreManifest), Boolean(this.options.errorOnManifestCreate))
     this.commands = Object
     .entries(this.manifest.commands)
-    .map(([id, c]) => ({...c, pluginAlias: this.alias, pluginType: this.type, load: async () => this.findCommand(id, {must: true})}))
+    .map(([id, c]) => ({
+      ...c,
+      pluginAlias: this.alias,
+      pluginType: c.pluginType === 'jit' ? 'jit' : this.type,
+      load: async () => this.findCommand(id, {must: true}),
+    }))
     .sort((a, b) => a.id.localeCompare(b.id))
   }
 

--- a/src/interfaces/hooks.ts
+++ b/src/interfaces/hooks.ts
@@ -42,7 +42,7 @@ export interface Hooks {
     return: unknown;
   };
   'jit_plugin_not_installed': {
-    options: {id: string; argv: string[]; command: Command.Loadable};
+    options: {id: string; argv: string[]; command: Command.Loadable, pluginName: string; pluginVersion: string};
     return: unknown;
   };
   'plugins:preinstall': {

--- a/src/interfaces/hooks.ts
+++ b/src/interfaces/hooks.ts
@@ -41,6 +41,10 @@ export interface Hooks {
     options: {id: string; argv: string[], matches: Command.Loadable[]};
     return: unknown;
   };
+  'jit_plugin_not_installed': {
+    options: {id: string; argv: string[]; command: Command.Loadable};
+    return: unknown;
+  };
   'plugins:preinstall': {
     options: {
       plugin: { name: string; tag: string; type: 'npm' } | { url: string; type: 'repo' };
@@ -60,6 +64,7 @@ export namespace Hook {
   export type Update = Hook<'update'>
   export type CommandNotFound = Hook<'command_not_found'>
   export type CommandIncomplete = Hook<'command_incomplete'>
+  export type JitPluginNotInstalled = Hook<'jit_plugin_not_installed'>
 
   export interface Context {
     config: Config;

--- a/src/interfaces/pjson.ts
+++ b/src/interfaces/pjson.ts
@@ -22,7 +22,7 @@ export namespace PJSON {
       default?: string;
       plugins?: string[];
       devPlugins?: string[];
-      jitPlugins?: string[];
+      jitPlugins?: Record<string, string>;
       helpClass?: string;
       helpOptions?: HelpOptions;
       aliases?: { [name: string]: string | null };

--- a/src/interfaces/pjson.ts
+++ b/src/interfaces/pjson.ts
@@ -22,6 +22,7 @@ export namespace PJSON {
       default?: string;
       plugins?: string[];
       devPlugins?: string[];
+      jitPlugins?: string[];
       helpClass?: string;
       helpOptions?: HelpOptions;
       aliases?: { [name: string]: string | null };

--- a/src/interfaces/pjson.ts
+++ b/src/interfaces/pjson.ts
@@ -81,6 +81,7 @@ export namespace PJSON {
       scope?: string;
       dirname?: string;
       flexibleTaxonomy?: boolean;
+      jitPlugins?: Record<string, string>;
     };
   }
 

--- a/src/interfaces/plugin.ts
+++ b/src/interfaces/plugin.ts
@@ -15,6 +15,7 @@ export interface PluginOptions {
 
 export interface Options extends PluginOptions {
   devPlugins?: boolean;
+  jitPlugins?: boolean;
   userPlugins?: boolean;
   channel?: string;
   version?: string;


### PR DESCRIPTION
Adds support for just-in-time plugin installation

Related:
https://github.com/oclif/oclif/pull/1009
https://github.com/salesforcecli/plugin-trust/pull/343

To use JIT plugins, add the following to the oclif section of the package.json

```json
"oclif": {
  "jitPlugins": {
    "@oclif/plugin-version": "^1.1.3", // this can be any valid semver
  }
}
```

#### Testing
1. Checkout all branches and run `yarn && yarn build`
  - https://github.com/oclif/core/pull/533
  - https://github.com/oclif/oclif/pull/1009
  - https://github.com/salesforcecli/plugin-trust/pull/343
2. yarn link `@oclif/core` to `oclif` branch (https://github.com/oclif/oclif/pull/1009)
3. yarn link `@oclif/core` to `@salesforce/plugin-trust` branch (https://github.com/salesforcecli/plugin-trust/pull/343) 
4. yarn link `@oclif/core`, `oclif`, `@salesforce/plugin-trust` to sf or sfdx repo
5. Run `yarn oclif manifest` in sf or sfdx repo
6. Add `@salesforce/plugin-packaging@1.12.2` as JIT plugin to sf or sfdx repo
```
"oclif": {
  "jitPlugins": {
    "@salesforce/plugin-packaging": "1.12.2"
  }
}
```
7. Run `bin/dev force:package:create --help` 
8. Run `bin/dev force:package:create` 

@W-12030328@