### PR TITLE
fix: ignore unset environment variables

### DIFF
--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -207,7 +207,7 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
     for (const k of Object.keys(this.input.flags)) {
       const flag = this.input.flags[k]
       if (flags[k]) continue
-      if (flag.env) {
+      if (flag.env && Object.prototype.hasOwnProperty.call(process.env, flag.env)) {
         const input = process.env[flag.env]
         if (flag.type === 'option') {
           if (input) {

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -910,6 +910,26 @@ See more help with --help`)
           delete process.env.TEST_FOO
         })
       }
+
+      it('ignores unset environment variables', async () => {
+        delete process.env.TEST_FOO
+        const out = await parse([], {
+          flags: {
+            foo: flags.boolean({env: 'TEST_FOO'}),
+          },
+        })
+        expect(out.flags.foo).to.be.undefined
+      })
+
+      it('uses default when environment variable is unset', async () => {
+        delete process.env.TEST_FOO
+        const out = await parse([], {
+          flags: {
+            foo: flags.boolean({env: 'TEST_FOO', default: true}),
+          },
+        })
+        expect(out.flags.foo).to.be.true
+      })
     })
   })
 


### PR DESCRIPTION
When an `env` is set for a boolean flag, if the user doesn't actually specify the value in their ENV, it ends up being treated as though they'd specified `false`. I don't think this is the correct behavior; instead, it should be considered unspecified.

This is especially relevant in 2 cases:

1. Boolean flags with `default: true`. As soon as you add an `env` config, they now effectively default to false.
2. Boolean flags with mutual exclusivity. If you specify one, oclif thinks you've specified both, and the command fails. You can reproduce easily:

```ts
import {Command, Flags} from '@oclif/core'

export default class Repro extends Command {
  static description = 'Reproduce exclusive flags bug'

  static flags = {
    exclusive1: Flags.string({
      required: false,
      env: 'SOME_ENV_VAR_1',
      exclusive: ['exclusive2'],
    }),
    exclusive2: Flags.boolean({
      required: false,
      env: 'SOME_ENV_VAR_2',
      exclusive: ['exclusive1'],
    }),
  }

  static args = []

  async run(): Promise<void> {
    const {flags} = await this.parse(Repro)
  }
}
```

```sh
$ bin/dev repro
# everything works fine

$ bin/dev repro --exclusive1
Error: The following error occurred:
  --exclusive1=true cannot also be provided when using --exclusive2
# ... stack trace ...

$ bin/dev repro --exclusive2
Error: The following error occurred:
  --exclusive2=true cannot also be provided when using --exclusive1
# ... stack trace ...
```