### PR TITLE
Fix OclifUX.ux.prompt() return type

### DIFF
--- a/src/cli-ux/action/base.ts
+++ b/src/cli-ux/action/base.ts
@@ -92,7 +92,7 @@ export class ActionBase {
     task.status = status
   }
 
-  public async pauseAsync(fn: () => Promise<any>, icon?: string) {
+  public async pauseAsync<T extends any>(fn: () => Promise<T>, icon?: string): Promise<T> {
     const task = this.task
     const active = task && task.active
     if (task && active) {

--- a/src/cli-ux/prompt.ts
+++ b/src/cli-ux/prompt.ts
@@ -120,9 +120,9 @@ function _prompt(name: string, inputOptions: Partial<IPromptOptions> = {}): Prom
  * prompt for input
  * @param name - prompt text
  * @param options - @see IPromptOptions
- * @returns void
+ * @returns Promise<string>
  */
-export function prompt(name: string, options: IPromptOptions = {}) {
+export function prompt(name: string, options: IPromptOptions = {}): Promise<string> {
   return config.action.pauseAsync(() => {
     return _prompt(name, options)
   }, chalk.cyan('?'))
@@ -149,9 +149,9 @@ export function confirm(message: string): Promise<boolean> {
 /**
  * "press anykey to continue"
  * @param message - optional message to display to user
- * @returns Promise<void>
+ * @returns Promise<string>
  */
-export async function anykey(message?: string): Promise<void> {
+export async function anykey(message?: string): Promise<string> {
   const tty = Boolean(process.stdin.setRawMode)
   if (!message) {
     message = tty ?


### PR DESCRIPTION
It's been a long standing issue that prompt returns a `Promise<any>` when it clearly should return `Promise<string>`. It's because the wrapper methods `pauseAsync()` don't forward their types along from the wrapped functions.

```ts
// This should not be valid
const foo: number = await = CliUx.ux.prompt('')
// this should be the normal type
const foo: string = await = CliUx.ux.prompt('')
```

I tried to sign the CLA but it failed the first time, and every subsequent time now I get `You already signed the CLA on 2022-10-25`.