### PR TITLE
Table: use screen from @oclif/core

### DIFF
--- a/src/cli-ux/styled/table.ts
+++ b/src/cli-ux/styled/table.ts
@@ -1,6 +1,6 @@
 import * as Interfaces from '../../interfaces'
 import * as F from '../../flags'
-import {stdtermwidth} from '@oclif/screen'
+import {stdtermwidth} from '../../screen'
 import * as chalk from 'chalk'
 import {capitalize, sumBy} from '../../util'
 import {safeDump} from 'js-yaml'


### PR DESCRIPTION
Hi! 

I've noticed that table is using `stdtermwidth` from `@oclif/screen` which is not good as screen implementation from core. 

Using screen from `@oclif/core` is now possible to use `process.env.OCLIF_COLUMNS=80` for example in tests or other places.