### PR TITLE
Fixes #592 by directly returning the result of commands to the caller

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -74,5 +74,5 @@ export async function run(argv = process.argv.slice(2), options?: Interfaces.Loa
   // as an argument, we need to add back the '.' to argv since it was stripped out earlier as part of the
   // command id.
   if (config.pjson.oclif.default === '.' && id === '.' && argv[0] === '.') argvSlice = ['.', ...argvSlice]
-  await config.runCommand(id, argvSlice, cmd)
+  return config.runCommand(id, argvSlice, cmd)
 }

--- a/test/command/main.test.ts
+++ b/test/command/main.test.ts
@@ -84,4 +84,9 @@ COMMANDS
   .do(() => run(['foo', 'bar', 'succeed'], path.resolve(__dirname, 'fixtures/typescript/package.json')))
   .do((output: any) => expect(output.stdout).to.equal('it works!\n'))
   .it('runs foo:bar:succeed with space separator')
+
+  fancy
+  .add('result', () => run(['foo', 'bar', 'succeed'], path.resolve(__dirname, 'fixtures/typescript/package.json')))
+  .do((output: any) => expect(output.result).to.equal('returned success!'))
+  .it('returns foo:bar:succeed result directly')
 })


### PR DESCRIPTION
This change allows callers to interact with the result of commands directly rather than having to rely on the filesystem as an intermediary.