### PR TITLE
Avoid nonExistentFlag error with strict set to false

### DIFF
--- a/src/parser/validate.ts
+++ b/src/parser/validate.ts
@@ -14,7 +14,7 @@ export async function validate(parse: {
   output: ParserOutput;
 }): Promise<void> {
   function validateArgs() {
-    if (parse.output.nonExistentFlags?.length > 0) {
+    if (parse.input.strict && parse.output.nonExistentFlags?.length > 0) {
       throw new NonExistentFlagsError({parse, flags: parse.output.nonExistentFlags})
     }
 

--- a/test/parser/validate.test.ts
+++ b/test/parser/validate.test.ts
@@ -152,6 +152,62 @@ describe('validate', () => {
     }
   })
 
+  it('throws when extra flags are provided', async () => {
+    const input = {
+      argv: [],
+      flags: {},
+      args: {},
+      strict: true,
+      context: {},
+      '--': true,
+    }
+
+    const output = {
+      args: {},
+      argv: [],
+      flags: {foobar: 'baz'},
+      raw: [],
+      metadata: {
+        flags: {},
+      },
+      nonExistentFlags: ['foobar'],
+    }
+
+    try {
+      // @ts-expect-error
+      await validate({input, output})
+      assert.fail('should have thrown')
+    } catch (error) {
+      const err = error as CLIError
+      expect(err.message).to.include('Nonexistent flag')
+    }
+  })
+
+  it("doesn't throw if extra flags are provided and strict is false", async () => {
+    const input = {
+      argv: [],
+      flags: {},
+      args: {},
+      strict: false,
+      context: {},
+      '--': true,
+    }
+
+    const output = {
+      args: {},
+      argv: [],
+      flags: {foobar: 'baz'},
+      raw: [],
+      metadata: {
+        flags: {},
+      },
+      nonExistentFlags: ['foobar'],
+    }
+
+    // @ts-expect-error
+    await validate({input, output})
+  })
+
   describe('relationships', () => {
     describe('type: all', () => {
       it('should pass if all required flags are provided', async () => {


### PR DESCRIPTION
I'm updating our CLI to v2 and we have noticed that this new check in `Parser.validate` doesn't respect `strict` to false.

Fixes #616 