### PR TITLE
fix: ignore hasDynamicHelp if JIT plugin

### DIFF
--- a/src/help/index.ts
+++ b/src/help/index.ts
@@ -104,7 +104,7 @@ export class Help extends HelpBase {
 
     const command = this.config.findCommand(subject)
     if (command) {
-      if (command.hasDynamicHelp) {
+      if (command.hasDynamicHelp && command.pluginType !== 'jit') {
         const dynamicCommand = await toCached(await command.load())
         await this.showCommandHelp(dynamicCommand)
       } else {


### PR DESCRIPTION
Ignored `hasDynamicHelp` when generating help for JIT plugins