### PR TITLE
fix: handling quoted strings and options validation for comma-delimited multiple-flag

### DIFF
--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -233,7 +233,7 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
           const values = await Promise.all(
             input.split(flag.delimiter).map(async v => this._parseFlag(v.trim().replace(/^"(.*)"$/, '$1'), flag, token)),
           )
-          // the parse that each element aligns with the `options` property
+          // then parse that each element aligns with the `options` property
           for (const v of values) {
             this._validateOptions(flag, v)
           }

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -231,7 +231,7 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
         if (flag.delimiter && flag.multiple) {
           // split, trim, and remove surrounding doubleQuotes (which would hav been needed if the elements contain spaces)
           const values = await Promise.all(
-            input.split(flag.delimiter).map(async v => this._parseFlag(v.trim().replace(/^"(.*)"$/, '$1'), flag, token)),
+            input.split(flag.delimiter).map(async v => this._parseFlag(v.trim().replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1'), flag, token)),
           )
           // then parse that each element aligns with the `options` property
           for (const v of values) {

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -227,15 +227,21 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
         flags[token.flag] = await this._parseFlag(flags[token.flag], flag, token)
       } else {
         const input = token.input
-        this._validateOptions(flag, input)
 
         if (flag.delimiter && flag.multiple) {
+          // split, trim, and remove surrounding doubleQuotes (which would hav been needed if the elements contain spaces)
           const values = await Promise.all(
-            input.split(flag.delimiter).map(async v => this._parseFlag(v.trim(), flag, token)),
+            input.split(flag.delimiter).map(async v => this._parseFlag(v.trim().replace(/^"(.*)"$/, '$1'), flag, token)),
           )
+          // the parse that each element aligns with the `options` property
+          for (const v of values) {
+            this._validateOptions(flag, v)
+          }
+
           flags[token.flag] = flags[token.flag] || []
           flags[token.flag].push(...values)
         } else {
+          this._validateOptions(flag, input)
           const value = await this._parseFlag(input, flag, token)
           if (flag.multiple) {
             flags[token.flag] = flags[token.flag] || []

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -355,7 +355,7 @@ See more help with --help`)
       it('allowed options on multiple', async () => {
         const out = await parse(['--foo', 'a', '--foo=b'], {
           flags: {
-            foo: Flags.custom({multiple: true, parse: async i => i, options: ['a', 'b']})(),
+            foo: Flags.string({multiple: true, parse: async i => i, options: ['a', 'b']}),
           },
         })
         expect(out.flags).to.deep.include({foo: ['a', 'b']})
@@ -364,7 +364,7 @@ See more help with --help`)
       it('one of allowed options on multiple', async () => {
         const out = await parse(['--foo', 'a'], {
           flags: {
-            foo: Flags.custom({multiple: true, parse: async i => i, options: ['a', 'b']})(),
+            foo: Flags.string({multiple: true, options: ['a', 'b']}),
           },
         })
         expect(out.flags).to.deep.include({foo: ['a']})
@@ -373,7 +373,7 @@ See more help with --help`)
         try {
           await parse(['--foo', 'a', '--foo=c'], {
             flags: {
-              foo: Flags.custom({multiple: true, parse: async i => i, options: ['a', 'b']})(),
+              foo: Flags.string({multiple: true, options: ['a', 'b']}),
             },
           })
         } catch (error:any) {
@@ -384,7 +384,7 @@ See more help with --help`)
         it('basic', async () => {
           const out = await parse(['--foo', 'a,b'], {
             flags: {
-              foo: Flags.custom({multiple: true, delimiter: ',', parse: async i => i})(),
+              foo: Flags.string({multiple: true, delimiter: ','}),
             },
           })
           expect(out.flags).to.deep.include({foo: ['a', 'b']})
@@ -392,7 +392,7 @@ See more help with --help`)
         it('with spaces inside quotes', async () => {
           const out = await parse(['--foo', '"a a","b b"'], {
             flags: {
-              foo: Flags.custom({multiple: true, delimiter: ',', parse: async i => i})(),
+              foo: Flags.string({multiple: true, delimiter: ','}),
             },
           })
           expect(out.flags).to.deep.include({foo: ['a a', 'b b']})
@@ -400,7 +400,7 @@ See more help with --help`)
         it('with options', async () => {
           const out = await parse(['--foo', 'a,b'], {
             flags: {
-              foo: Flags.custom({multiple: true, delimiter: ',', parse: async i => i, options: ['a', 'b']})(),
+              foo: Flags.string({multiple: true, delimiter: ',', options: ['a', 'b']}),
             },
           })
           expect(out.flags).to.deep.include({foo: ['a', 'b']})
@@ -409,7 +409,7 @@ See more help with --help`)
           try {
             await parse(['--foo', 'a,c'], {
               flags: {
-                foo: Flags.custom({multiple: true, parse: async i => i, options: ['a', 'b']})(),
+                foo: Flags.string({multiple: true, options: ['a', 'b']}),
               },
             })
           } catch (error:any) {
@@ -420,7 +420,7 @@ See more help with --help`)
         it('with options and quotes with spaces', async () => {
           const out = await parse(['--foo', '"a a","b b"'], {
             flags: {
-              foo: Flags.custom({multiple: true, delimiter: ',', parse: async i => i, options: ['a a', 'b b']})(),
+              foo: Flags.string({multiple: true, delimiter: ',', options: ['a a', 'b b']}),
             },
           })
           expect(out.flags).to.deep.include({foo: ['a a', 'b b']})
@@ -429,7 +429,7 @@ See more help with --help`)
           try {
             await parse(['--foo', '"a a","b c"'], {
               flags: {
-                foo: Flags.custom({multiple: true, delimiter: ',', parse: async i => i, options: ['a a', 'b b']})(),
+                foo: Flags.string({multiple: true, delimiter: ',', options: ['a a', 'b b']}),
               },
             })
           } catch (error:any) {

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -389,6 +389,22 @@ See more help with --help`)
           })
           expect(out.flags).to.deep.include({foo: ['a', 'b']})
         })
+        it('preserves non-exterior double quotes (single and pairs)', async () => {
+          const out = await parse(['--foo', 'a,",b,hi"yo"'], {
+            flags: {
+              foo: Flags.string({multiple: true, delimiter: ','}),
+            },
+          })
+          expect(out.flags).to.deep.include({foo: ['a', '"', 'b', 'hi"yo"']})
+        })
+        it('preserves non-exterior single quotes (single and pairs)', async () => {
+          const out = await parse(['--foo', "a,',b,hi'yo'"], {
+            flags: {
+              foo: Flags.string({multiple: true, delimiter: ','}),
+            },
+          })
+          expect(out.flags).to.deep.include({foo: ['a', "'", 'b', "hi'yo'"]})
+        })
         it('with spaces inside double quotes', async () => {
           const out = await parse(['--foo', '"a a","b b"'], {
             flags: {

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -389,8 +389,16 @@ See more help with --help`)
           })
           expect(out.flags).to.deep.include({foo: ['a', 'b']})
         })
-        it('with spaces inside quotes', async () => {
+        it('with spaces inside double quotes', async () => {
           const out = await parse(['--foo', '"a a","b b"'], {
+            flags: {
+              foo: Flags.string({multiple: true, delimiter: ','}),
+            },
+          })
+          expect(out.flags).to.deep.include({foo: ['a a', 'b b']})
+        })
+        it('with spaces inside single quotes', async () => {
+          const out = await parse(['--foo', "'a a','b b'"], {
             flags: {
               foo: Flags.string({multiple: true, delimiter: ','}),
             },
@@ -417,7 +425,7 @@ See more help with --help`)
           }
         })
 
-        it('with options and quotes with spaces', async () => {
+        it('with options and double quotes with spaces', async () => {
           const out = await parse(['--foo', '"a a","b b"'], {
             flags: {
               foo: Flags.string({multiple: true, delimiter: ',', options: ['a a', 'b b']}),
@@ -425,9 +433,28 @@ See more help with --help`)
           })
           expect(out.flags).to.deep.include({foo: ['a a', 'b b']})
         })
-        it('throws if non-allowed comma as delimiter with options and quotes with spaces', async () => {
+        it('with options and single quotes with spaces', async () => {
+          const out = await parse(['--foo', "'a a','b b'"], {
+            flags: {
+              foo: Flags.string({multiple: true, delimiter: ',', options: ['a a', 'b b']}),
+            },
+          })
+          expect(out.flags).to.deep.include({foo: ['a a', 'b b']})
+        })
+        it('throws if non-allowed with options and double quotes with spaces', async () => {
           try {
             await parse(['--foo', '"a a","b c"'], {
+              flags: {
+                foo: Flags.string({multiple: true, delimiter: ',', options: ['a a', 'b b']}),
+              },
+            })
+          } catch (error:any) {
+            expect(error.message).to.include('Expected --foo=b c to be one of: a a, b b')
+          }
+        })
+        it('throws if non-allowed with options and single quotes with spaces', async () => {
+          try {
+            await parse(['--foo', "'a a','b c'"], {
               flags: {
                 foo: Flags.string({multiple: true, delimiter: ',', options: ['a a', 'b b']}),
               },


### PR DESCRIPTION
1. --multiFlag would validate options agains the combined input BEFORE splitting when it used a delimiter.
2. strings can be double-quoted when they contain spaces.  This removes surrounding quotes from the items before validating against the options.


side note about error messages assertion changes:
test cases would run find from `yarn test` but fail when running the individual test becuase of ASCII color codes in the results.  They've been modified to "include" the expected strings to make them color-blind