### PR TITLE
feat: add param to runHook to capture errors

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -230,7 +230,12 @@ export class Config implements IConfig {
     }
   }
 
-  public async runHook<T extends keyof Hooks>(event: T, opts: Hooks[T]['options'], timeout?: number): Promise<Hook.Result<Hooks[T]['return']>> {
+  public async runHook<T extends keyof Hooks>(
+    event: T,
+    opts: Hooks[T]['options'],
+    timeout?: number,
+    captureErrors?: boolean,
+  ): Promise<Hook.Result<Hooks[T]['return']>> {
     debug('start %s hook', event)
     const search = (m: any): Hook<T> => {
       if (typeof m === 'function') return m
@@ -293,6 +298,7 @@ export class Config implements IConfig {
         } catch (error: any) {
           final.failures.push({plugin: p, error: error as Error})
           debug(error)
+          if (!captureErrors && error.oclif?.exit !== undefined) throw error
         }
       }
     })


### PR DESCRIPTION
Adds new `captureErrors` parameter to `Config.runHook`. If it's `true`, errors from hooks will be captured and returned to the caller; if it's `false` or `undefined`, all errors will be thrown
 
Fixes #515 
Fixes https://github.com/oclif/oclif/issues/1083

@W-12514447@