### PR TITLE
fix: move `@types/cli-progress` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/core/issues",
   "dependencies": {
-    "@types/cli-progress": "^3.11.0",
     "ansi-escapes": "^4.3.2",
     "ansi-styles": "^4.3.0",
     "cardinal": "^2.1.1",
@@ -43,6 +42,7 @@
     "@types/chai": "^4.3.4",
     "@types/chai-as-promised": "^7.1.5",
     "@types/clean-stack": "^2.1.1",
+    "@types/cli-progress": "^3.11.0",
     "@types/ejs": "^3.1.2",
     "@types/fs-extra": "^9.0.13",
     "@types/indent-string": "^4.0.1",

--- a/src/cli-ux/styled/progress.ts
+++ b/src/cli-ux/styled/progress.ts
@@ -1,5 +1,6 @@
 // 3pp
-import {Options, SingleBar} from 'cli-progress'
+import type {Options} from 'cli-progress'
+import {SingleBar} from 'cli-progress'
 
 export default function progress(options: Options = {}): SingleBar {
   // set noTTYOutput for options


### PR DESCRIPTION
`@types/cli-progress` was in normal `dependencies`, although all the `@types/xxx` packages are really `devDependencies`.

This was an issue since `@types/cli-progress` depends on `@types/node`, which is huge (7 MB), and it was making our CLI quite fat.

I see this was [added in v2](https://github.com/oclif/core/pull/539), but I feel like it was not on purpose?