### PR TITLE
Auto-compile linked plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "strip-ansi": "^6.0.1",
     "supports-color": "^8.1.1",
     "supports-hyperlinks": "^2.2.0",
+    "ts-node": "^10.9.1",
     "tslib": "^2.5.0",
     "widest-line": "^3.1.0",
     "wordwrap": "^1.0.0",
@@ -73,7 +74,6 @@
     "shelljs": "^0.8.5",
     "shx": "^0.3.4",
     "sinon": "^11.1.2",
-    "ts-node": "^10.9.1",
     "tsd": "^0.25.0",
     "typescript": "^4.9.5"
   },

--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -127,6 +127,8 @@ export class Plugin implements IPlugin {
 
   hasManifest = false
 
+  private _commandsDir!: string | undefined
+
   // eslint-disable-next-line new-cap
   protected _debug = Debug()
 
@@ -175,7 +177,10 @@ export class Plugin implements IPlugin {
   }
 
   public get commandsDir(): string | undefined {
-    return tsPath(this.root, this.pjson.oclif.commands)
+    if (this._commandsDir) return this._commandsDir
+
+    this._commandsDir = tsPath(this.root, this.pjson.oclif.commands, this.type)
+    return this._commandsDir
   }
 
   public get commandIDs(): string[] {
@@ -217,7 +222,7 @@ export class Plugin implements IPlugin {
 
       let m
       try {
-        const p = path.join(this.pjson.oclif.commands as string, ...id.split(':'))
+        const p = path.join(this.commandsDir ?? this.pjson.oclif.commands, ...id.split(':'))
         const {isESM, module, filePath} = await ModuleLoader.loadWithData(this, p)
         this._debug(isESM ? '(import)' : '(require)', filePath)
         m = module

--- a/src/config/ts-node.ts
+++ b/src/config/ts-node.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs'
 import * as path from 'path'
+import * as TSNode from 'ts-node'
 
 import {TSConfig} from '../interfaces/ts-config'
 import {settings} from '../settings'
@@ -34,14 +35,56 @@ function loadTSConfig(root: string): TSConfig | undefined {
   }
 }
 
+const TS_CONFIGS: Record<string, TSConfig> = {}
+const TYPE_ROOTS = [`${__dirname}/../node_modules/@types`]
+const ROOT_DIRS: string[] = []
+function registerTSNode(root: string) {
+  if (TS_CONFIGS[root]) return
+  const tsconfig = loadTSConfig(root)
+  if (!tsconfig) return
+  debug('registering ts-node at', root)
+  const tsNodePath = require.resolve('ts-node', {paths: [root, __dirname]})
+  const tsNode: typeof TSNode = require(tsNodePath)
+  TS_CONFIGS[root] = tsconfig
+  TYPE_ROOTS.push(`${root}/node_modules/@types`)
+
+  if (tsconfig.compilerOptions.rootDirs) {
+    ROOT_DIRS.push(...tsconfig.compilerOptions.rootDirs.map(r => path.join(root, r)))
+  } else {
+    ROOT_DIRS.push(`${root}/src`)
+  }
+
+  const cwd = process.cwd()
+  try {
+    process.chdir(root)
+    tsNode.register({
+      skipProject: true,
+      transpileOnly: true,
+      compilerOptions: {
+        esModuleInterop: tsconfig.compilerOptions.esModuleInterop,
+        target: tsconfig.compilerOptions.target || 'es2017',
+        experimentalDecorators: tsconfig.compilerOptions.experimentalDecorators || false,
+        emitDecoratorMetadata: tsconfig.compilerOptions.emitDecoratorMetadata || false,
+        module: 'commonjs',
+        sourceMap: true,
+        rootDirs: ROOT_DIRS,
+        typeRoots: TYPE_ROOTS,
+        jsx: 'react',
+      },
+    })
+  } finally {
+    process.chdir(cwd)
+  }
+}
+
 /**
- * convert a path from the compiled ./lib files to the ./src typescript source
+ * Convert a path from the compiled ./lib files to the ./src typescript source
  * this is for developing typescript plugins/CLIs
- * if there is a tsconfig and the original sources exist, it attempts to require ts-
+ * if there is a tsconfig and the original sources exist, it attempts to require ts-node
  */
-export function tsPath(root: string, orig: string): string
-export function tsPath(root: string, orig: string | undefined): string | undefined
-export function tsPath(root: string, orig: string | undefined): string | undefined {
+export function tsPath(root: string, orig: string, type?: string): string
+export function tsPath(root: string, orig: string | undefined, type?: string): string | undefined
+export function tsPath(root: string, orig: string | undefined, type?: string): string | undefined {
   if (!orig) return orig
   orig = path.join(root, orig)
 
@@ -51,10 +94,11 @@ export function tsPath(root: string, orig: string | undefined): string | undefin
     // the CLI didn't specify ts-node and it is production
     (settings.tsnodeEnabled === undefined && isProd())
 
-  if (skipTSNode) return orig
+  // We always want to load the tsconfig for linked plugins.
+  if (skipTSNode && type !== 'link') return orig
 
   try {
-    const tsconfig = loadTSConfig(root)
+    const tsconfig = type === 'link' ? registerTSNode(root) : loadTSConfig(root)
     if (!tsconfig) return orig
     const {rootDir, rootDirs, outDir} = tsconfig.compilerOptions
     const rootDirPath = rootDir || (rootDirs || [])[0]


### PR DESCRIPTION
Register ts-node for linked plugins so that developers don't have to compile their plugin before running it

More context: https://github.com/forcedotcom/cli/issues/1664
@W-12652231@

### Testing

- `yarn link @oclif/core` in sfdx-cli
- cd to `oclif/plugin-plugins`
  - run `sfdx plugins link`
  - run `rm -rf lib/`
- cd to sfdx-cli
  - [ ] `bin/dev plugins`
  - [ ] `bin/run plugins`
  - [ ] `bin/dev version`
  - [ ] `bin/run version`
- cd to `oclif/plugin-plugins`
  - run `yarn build`
- cd to sfdx-cli
  - [ ] `bin/dev plugins`
  - [ ] `bin/run plugins`
  - [ ] `bin/dev version`
  - [ ] `bin/run version`

