### PR TITLE
feat: add Config.versionDetails

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -6,7 +6,7 @@ import {fileURLToPath, URL} from 'url'
 import {format} from 'util'
 
 import {Options, Plugin as IPlugin} from '../interfaces/plugin'
-import {Config as IConfig, ArchTypes, PlatformTypes, LoadOptions} from '../interfaces/config'
+import {Config as IConfig, ArchTypes, PlatformTypes, LoadOptions, VersionDetails} from '../interfaces/config'
 import {Hook, Hooks, PJSON, Topic} from '../interfaces'
 import * as Plugin from './plugin'
 import {Debug, compact, loadJSON, collectUsableIds, getCommandIdPermutations} from './util'
@@ -495,6 +495,19 @@ export class Config implements IConfig {
 
   public get topics(): Topic[] {
     return [...this._topics.values()]
+  }
+
+  public get versionDetails(): VersionDetails {
+    const [cliVersion, architecture, nodeVersion] = this.userAgent.split(' ')
+    return {
+      cliVersion,
+      architecture,
+      nodeVersion,
+      pluginVersions: Object.fromEntries(this.plugins.map(p => [p.name, {version: p.version, type: p.type, root: p.root}])),
+      osVersion: `${os.type()} ${os.release()}`,
+      shell: this.shell,
+      rootPath: this.root,
+    }
   }
 
   public s3Key(type: keyof PJSON.S3.Templates, ext?: '.tar.gz' | '.tar.xz' | IConfig.s3Key.Options, options: IConfig.s3Key.Options = {}): string {

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -8,6 +8,16 @@ export type LoadOptions = Options | string | Config | undefined
 export type PlatformTypes = 'darwin' | 'linux' | 'win32' | 'aix' | 'freebsd' | 'openbsd' | 'sunos' | 'wsl'
 export type ArchTypes = 'arm' | 'arm64' | 'mips' | 'mipsel' | 'ppc' | 'ppc64' | 's390' | 's390x' | 'x32' | 'x64' | 'x86'
 
+export type VersionDetails = {
+  cliVersion: string;
+  architecture: string;
+  nodeVersion: string;
+  pluginVersions?: Record<string, {version: string; type: string; root: string}>;
+  osVersion?: string;
+  shell?: string;
+  rootPath?: string;
+}
+
 export interface Config {
   name: string;
   version: string;


### PR DESCRIPTION
Adds `Config.versionDetails` so that multiple consumers can get detailed version information without having to use plugin-version directly