### PR TITLE
fix: pass plugin type when resolving a module path

### DIFF
--- a/src/module-loader.ts
+++ b/src/module-loader.ts
@@ -136,11 +136,15 @@ export default class ModuleLoader {
     let isESM: boolean
     let filePath: string
 
+    const isPlugin = (config: IConfig|IPlugin): config is IPlugin => {
+      return (<IPlugin>config).type !== undefined
+    }
+
     try {
       filePath = require.resolve(modulePath)
       isESM = ModuleLoader.isPathModule(filePath)
     } catch {
-      filePath = Config.tsPath(config.root, modulePath)
+      filePath = isPlugin(config) ? Config.tsPath(config.root, modulePath, config.type) : Config.tsPath(config.root, modulePath)
 
       let fileExists = false
       let isDirectory = false


### PR DESCRIPTION
This fixes a bug where linked plugins with hooks were causing a CLI to fail with the `ModuleLoadError: [MODULE_NOT_FOUND] require failed to load`.

https://github.com/oclif/core/pull/650 introduced compilation at runtime for linked TS plugins using `ts-node`.
When trying to compile hooks from linked plugins oclif isn't passing the `plugin.type` prop to the ts path resolver so `tsPath` was just skipping the compilation step.

## Before:
![Screenshot 2023-03-16 at 10 07 02](https://user-images.githubusercontent.com/6853656/225626165-64490096-822d-4d74-a9c0-9acd60cfbdfb.png)

## After
![Screenshot 2023-03-16 at 10 07 32](https://user-images.githubusercontent.com/6853656/225626268-743f78bb-fc30-49ec-9fd9-91ad4a98a2e4.png)

### Testing

**Repro**
- cd to `plugin-info` (doctor hook)
  - run `rm -rf lib`
  - run `../sfdx-cli/bin/run plugins:link .`
  - run `../sfdx-cli/bin/run`, should see the `MODULE_NOT_FOUND`

**QA**
  - yarn link @oclif/core in sfdx-cli
  - cd to `plugin-info` (doctor hook)
  - run `rm -rf lib`
  - run `../sfdx-cli/bin/run plugins:link .`
  - run `../sfdx-cli/bin/run`, CLI should work.