### PR TITLE
fix: add flag name and short char to deprecation message

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -280,17 +280,23 @@ export abstract class Command {
 
   protected warnIfFlagDeprecated(flags: Record<string, unknown>): void {
     for (const flag of Object.keys(flags)) {
-      const deprecated = this.ctor.flags[flag]?.deprecated
+      const flagDef = this.ctor.flags[flag]
+      const deprecated = flagDef?.deprecated
       if (deprecated) {
         this.warn(formatFlagDeprecationWarning(flag, deprecated))
       }
 
-      const deprecateAliases = this.ctor.flags[flag]?.deprecateAliases
-      const aliases = (this.ctor.flags[flag]?.aliases ?? []).map(a => a.length === 1 ? `-${a}` : `--${a}`)
+      const deprecateAliases = flagDef?.deprecateAliases
+      const aliases = (flagDef?.aliases ?? []).map(a => a.length === 1 ? `-${a}` : `--${a}`)
       if (deprecateAliases && aliases.length > 0) {
         const foundAliases = aliases.filter(alias => this.argv.some(a => a.startsWith(alias)))
         for (const alias of foundAliases) {
-          this.warn(formatFlagDeprecationWarning(alias, {to: this.ctor.flags[flag]?.name}))
+          let preferredUsage = `--${flagDef?.name}`
+          if (flagDef?.char) {
+            preferredUsage += ` | -${flagDef?.char}`
+          }
+
+          this.warn(formatFlagDeprecationWarning(alias, {to: preferredUsage}))
         }
       }
     }

--- a/src/help/util.ts
+++ b/src/help/util.ts
@@ -108,7 +108,7 @@ export function formatFlagDeprecationWarning(flag: string, opts: true | Deprecat
     message += ` and will be removed in version ${opts.version}`
   }
 
-  message += opts.to ? `. Use "--${opts.to}" instead.` : '.'
+  message += opts.to ? `. Use "${opts.to}" instead.` : '.'
 
   return message
 }

--- a/test/command/command.test.ts
+++ b/test/command/command.test.ts
@@ -268,6 +268,7 @@ describe('command', () => {
         name: Flags.string({
           aliases: ['username', 'target-user', 'u'],
           deprecateAliases: true,
+          char: 'o',
         }),
         other: Flags.string(),
       }
@@ -282,21 +283,21 @@ describe('command', () => {
     .stdout()
     .stderr()
     .do(async () => CMD.run(['--username', 'astro']))
-    .do(ctx => expect(ctx.stderr).to.include('Warning: The "--username" flag has been deprecated'))
+    .do(ctx => expect(ctx.stderr).to.include('Warning: The "--username" flag has been deprecated. Use "--name | -o"'))
     .it('shows warning for deprecated flag alias')
 
     fancy
     .stdout()
     .stderr()
     .do(async () => CMD.run(['--target-user', 'astro']))
-    .do(ctx => expect(ctx.stderr).to.include('Warning: The "--target-user" flag has been deprecated'))
+    .do(ctx => expect(ctx.stderr).to.include('Warning: The "--target-user" flag has been deprecated. Use "--name | -o"'))
     .it('shows warning for deprecated flag alias')
 
     fancy
     .stdout()
     .stderr()
     .do(async () => CMD.run(['-u', 'astro']))
-    .do(ctx => expect(ctx.stderr).to.include('Warning: The "-u" flag has been deprecated'))
+    .do(ctx => expect(ctx.stderr).to.include('Warning: The "-u" flag has been deprecated. Use "--name | -o"'))
     .it('shows warning for deprecated short char flag alias')
 
     fancy


### PR DESCRIPTION
To improve the command flag deprecation warnings, the flag name and (if it exists) the flag short char is included in the warning.

@W-12528771@