### PR TITLE
fix: update config to not use node prefix imports

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -18,8 +18,6 @@ import {CompletableOptionFlag, Arg} from '../interfaces/parser'
 import {stdout} from '../cli-ux/stream'
 import {Performance} from '../performance'
 import {settings} from '../settings'
-import {userInfo as osUserInfo} from 'node:os'
-import {sep} from 'node:path'
 
 // eslint-disable-next-line new-cap
 const debug = Debug()
@@ -553,7 +551,7 @@ export class Config implements IConfig {
   protected _shell(): string {
     let shellPath
     const COMSPEC = process.env.COMSPEC
-    const SHELL = process.env.SHELL ?? osUserInfo().shell?.split(sep)?.pop()
+    const SHELL = process.env.SHELL ?? os.userInfo().shell?.split(path.sep)?.pop()
     if (SHELL) {
       shellPath = SHELL.split('/')
     } else if (this.windows && COMSPEC) {

--- a/test/config/config.shell.test.ts
+++ b/test/config/config.shell.test.ts
@@ -1,9 +1,9 @@
 import {expect} from 'chai'
 import {Config} from '../../src'
-import {userInfo as osUserInfo} from 'node:os'
-import {sep} from 'node:path'
+import {sep} from 'path'
+import {userInfo} from 'os'
 
-const getShell = () => osUserInfo().shell?.split(sep)?.pop() || 'unknown'
+const getShell = () => userInfo().shell?.split(sep)?.pop() || 'unknown'
 
 describe('config shell', () => {
   it('has a default shell', () => {


### PR DESCRIPTION
 - to support node >=14
 - https://nodejs.org/docs/latest-v14.x/api/esm.html#esm_node_imports
 - only supported  v14.18.0 (ESM import and CommonJS require()), v14.13.1 (only ESM import)