### PR TITLE
feat: add extensions to esm checking

### DIFF
--- a/src/module-loader.ts
+++ b/src/module-loader.ts
@@ -108,12 +108,13 @@ export default class ModuleLoader {
 
     switch (extension) {
     case '.js':
-      return getPackageType.sync(filePath) === 'module'
-
+    case '.jsx':
     case '.ts':
+    case '.tsx':
       return getPackageType.sync(filePath) === 'module'
 
     case '.mjs':
+    case '.mts':
       return true
 
     default:


### PR DESCRIPTION
After I changed my setup according to https://oclif.io/docs/esm, I got an error when loading `.tsx` files/commands.
`(node:3021523) [ERR_REQUIRE_ESM] Error Plugin: test-cli: Must use import to load ES Module: /[...]/test-cli/src/commands/hello/index.tsx`.

This PR adds the `.tsx`, `.jsx` and `.mts` extension to be handled in `ModuleLoader::isPathModule`.