### PR TITLE
fix(module-loader): fix detecting esm for tsx and jsx file extensions

### DIFF
--- a/src/module-loader.ts
+++ b/src/module-loader.ts
@@ -108,9 +108,9 @@ export default class ModuleLoader {
 
     switch (extension) {
     case '.js':
-      return getPackageType.sync(filePath) === 'module'
-
+    case '.jsx':
     case '.ts':
+    case '.tsx':
       return getPackageType.sync(filePath) === 'module'
 
     case '.mjs':


### PR DESCRIPTION
This PR is intended to fix loading .tsx and .jsx file when using ESM.

This is based on the fix from here: https://github.com/oclif/core/pull/694