### PR TITLE
fix: don't truncate at OCLIF level

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "lint": "eslint . --ext .ts --config .eslintrc",
     "posttest": "yarn lint",
     "prepack": "yarn run build",
-    "test": "mocha --forbid-only \"test/**/*.test.ts\"",
+    "test": "mocha --forbid-only \"test/**/*.test.ts\" --tiimeout 1200000",
     "test:e2e": "mocha --forbid-only \"test/**/*.e2e.ts\" --timeout 1200000",
     "pretest": "yarn build --noEmit && tsc -p test --noEmit --skipLibCheck"
   },

--- a/src/cli-ux/styled/table.ts
+++ b/src/cli-ux/styled/table.ts
@@ -42,7 +42,7 @@ class Table<T extends Record<string, unknown>> {
       extended,
       filter,
       'no-header': options['no-header'] ?? false,
-      'no-truncate': options['no-truncate'] ?? false,
+      'no-truncate': options['no-truncate'] ?? true,
       printLine: printLine ?? ((s: any) => stdout.write(s + '\n')),
       rowStart: ' ',
       sort,


### PR DESCRIPTION
What does this PR do?
no-truncate table output at the `oclif` level

What issues does this PR fix or reference?
@W-13003428@
https://github.com/forcedotcom/cli/issues/2048

for when commands call directly into OCLIF's `ux.table` method don't truncate output