### PR TITLE
test: restore node20 e2e

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,10 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        # node_version: [lts/-1, lts/*, latest]
-        node_version: [lts/-1, lts/*]
+        node_version: [lts/-1, lts/*, latest]
         exclude:
-          # - os: windows-latest
-          #   node_version: lts/*
+          - os: windows-latest
+            node_version: lts/*
           - os: windows-latest
             node_version: lts/-1
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         exclude:
           - os: windows-latest
             node_version: lts/*
-          - os: windows-latest
+          - os: windows-latest 
             node_version: lts/-1
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  unit-tests:
-    uses: oclif/github-workflows/.github/workflows/unitTest.yml@main
+  yarn-lockfile-check:
+    uses: salesforcecli/github-workflows/.github/workflows/lockFileCheck.yml@main
+  linux-unit-tests:
+    needs: yarn-lockfile-check
+    uses: salesforcecli/github-workflows/.github/workflows/unitTestsLinux.yml@main
+  windows-unit-tests:
+    needs: linux-unit-tests
+    uses: salesforcecli/github-workflows/.github/workflows/unitTestsWindows.yml@main
   e2e:
+    needs: linux-unit-tests
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]

--- a/test/integration/plugins.e2e.ts
+++ b/test/integration/plugins.e2e.ts
@@ -57,7 +57,7 @@ describe('oclif plugins', () => {
         expect(help.output).to.include('List installed plugins.')
       })
       it('should show usage', () => {
-        expect(help.output).to.include('USAGE\n  $ oclif-hello-world plugins [--core]')
+        expect(help.output).to.include('USAGE\n  $ oclif-hello-world plugins [--json] [--core]')
       })
       it('should show description', () => {
         expect(help.output).to.include('DESCRIPTION\n  List installed plugins.')

--- a/test/integration/plugins.e2e.ts
+++ b/test/integration/plugins.e2e.ts
@@ -1,6 +1,8 @@
 import * as os from 'os'
-import {expect} from 'chai'
+import {expect, config as chaiConfig} from 'chai'
 import {Executor, Result, setup} from './util'
+
+chaiConfig.truncateThreshold = 0
 
 describe('oclif plugins', () => {
   let executor: Executor


### PR DESCRIPTION
@W-13130355@

change e2e test to account for https://github.com/oclif/plugin-plugins/pull/609
oclif can use the salesforcecli/gh-workflows UT actions and lockfile check (no secrets:inherit)

node20 problem was this (newer supports node20) https://github.com/salesforcecli/cli/pull/873/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L241