### PR TITLE
fix: correctly load legacy plugins

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -805,10 +805,24 @@ export class Config implements IConfig {
     return commandPlugins[0]
   }
 
+  /**
+    * Insert legacy plugins
+    *
+    * Replace invalid CLI plugins (cli-engine plugins, mostly Heroku) loaded via `this.loadPlugins`
+    * with oclif-compatible ones returned by @oclif/plugin-legacy init hook.
+    *
+    * @param plugins array of oclif-compatible plugins
+    * @returns void
+    */
   private insertLegacyPlugins(plugins: IPlugin[]) {
     for (const plugin of plugins) {
       const idx = this.plugins.findIndex(p => p.name === plugin.name)
-      if (idx !== -1) this.plugins = this.plugins.splice(idx, 1, plugin)
+      if (idx !== -1) {
+        // invalid plugin instance found in `this.plugins`
+        // replace with the oclif-compatible one
+        this.plugins.splice(idx, 1, plugin)
+      }
+
       this.loadCommands(plugin)
     }
   }


### PR DESCRIPTION
This PR fixes an issue where CLIs that includes `@oclif/plugin-legacy` and at least one [old, invalid plugin ](https://github.com/oclif/core/blob/main/src/config/plugin.ts#L161-L165) would get legacy plugins as the only ones installed.

 left: ci-v5 plugin installed, shows as the only plugin (`--core` should show core plugins too), `plugins:inspect webhooks` fails even though `@heroku-cli/plugin-webhooks` is a core plugin. 
right: with oclif fix, `plugins:inspect` is able to find it.
![Screenshot 2023-06-15 at 13 31 52](https://github.com/oclif/core/assets/6853656/2aa62f8c-82c6-4876-803b-d0cdc485647f)

plugin-legacy init hook where invalid, legacy plugins are converted:
https://github.com/oclif/plugin-legacy/blob/main/src/hooks/init.ts

### Repro

1. install Heroku CLI: `npm i -g heroku`
2. check core plugins: `heroku plugins --core`, this only returns `addons-v5 8.1.7 (core)` because it's the first invalid plugin found.
3. modify the splice line in the JS code 
4. run `heroku plugins --core` again, should get all core plugins.

[skip-validate-pr]