### PR TITLE
[DO NOT MERGE] Adds a new subtype for non-boolean types

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -416,6 +416,7 @@ export namespace Command {
     examples?: Example[];
     strict?: boolean;
     type?: string;
+    subType?: string;
     pluginName?: string;
     pluginType?: string;
     pluginAlias?: string;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -897,6 +897,7 @@ export async function toCached(c: Command.Class, plugin?: IPlugin | undefined, i
       flags[name] = {
         name,
         type: flag.type,
+        subType: flag.subType,
         char: flag.char,
         summary: flag.summary,
         description: flag.description,

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -53,6 +53,7 @@ export function boolean<T = boolean>(
 }
 
 export const integer = custom<number, {min?: number; max?: number;}>({
+  subType: 'integer',
   parse: async (input, _, opts) => {
     if (!/^-?\d+$/.test(input))
       throw new Error(`Expected an integer but received: ${input}`)
@@ -66,6 +67,7 @@ export const integer = custom<number, {min?: number; max?: number;}>({
 })
 
 export const directory = custom<string, {exists?: boolean}>({
+  subType: 'directory',
   parse: async (input, _, opts) => {
     if (opts.exists) return dirExists(input)
 
@@ -74,6 +76,7 @@ export const directory = custom<string, {exists?: boolean}>({
 })
 
 export const file = custom<string, {exists?: boolean}>({
+  subType: 'file',
   parse: async (input, _, opts) => {
     if (opts.exists) return fileExists(input)
 
@@ -86,6 +89,7 @@ export const file = custom<string, {exists?: boolean}>({
  * if the string is not a valid URL.
  */
 export const url = custom<URL>({
+  subType: 'url',
   parse: async input => {
     try {
       return new URL(input)
@@ -95,7 +99,7 @@ export const url = custom<URL>({
   },
 })
 
-const stringFlag = custom({})
+const stringFlag = custom({subType: 'string'})
 export {stringFlag as string}
 
 export const version = (opts: Partial<BooleanFlag<boolean>> = {}): BooleanFlag<void> => {

--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -256,6 +256,7 @@ export type BooleanFlagProps = FlagProps & {
 
 export type OptionFlagProps = FlagProps & {
   type: 'option';
+  subType?: string;
   helpValue?: string;
   options?: string[];
   multiple?: boolean;
@@ -294,6 +295,7 @@ export type OptionFlagDefaults<T, P = CustomOptions, M = false> = FlagProps & Op
   parse: FlagParser<T, string, P>
   defaultHelp?: FlagDefaultHelp<T>;
   input: string[];
+  subType?: string;
   default?: M extends true ? FlagDefault<T[] | undefined, P> : FlagDefault<T | undefined, P>;
 }
 


### PR DESCRIPTION
Right now, a oclif flag `type` can only be `boolean` or `option`. This limits the information that you could learn about the command programmatically using the `--json` flag. Rather than adding other flag types for `type`, we add a new `subType` value that specifies the actual flag type

https://github.com/forcedotcom/cli/issues/279

Testing
- Pull branch
- `yarn build`
- `yarn link`
- Go to `plugin-command`
- yarn link "@oclif/core"
- Run `bin/dev commands --json`
- Note that the new `subType` values are correct for this command's flags