### PR TITLE
Enforced arg prefixes (-) when matching flags.

### DIFF
--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -84,6 +84,22 @@ describe('parse', () => {
         expect(Boolean(out.flags.myflag2)).to.equal(true)
       })
 
+      it('doesn\'t throw when 2nd char in value matches a flag char', async () => {
+        const out =   await parse(['--myflag', 'Ishikawa', '-s', 'value'], {
+          flags: {myflag: Flags.string(), second: Flags.string({char: 's'})},
+        })
+        expect(out.flags.myflag).to.equal('Ishikawa')
+        expect(out.flags.second).to.equal('value')
+      })
+
+      it('doesn\'t throw when an unprefixed flag value contains a flag name', async () => {
+        const out =   await parse(['--myflag', 'a-second-place-finish', '-s', 'value'], {
+          flags: {myflag: Flags.string(), second: Flags.string({char: 's'})},
+        })
+        expect(out.flags.myflag).to.equal('a-second-place-finish')
+        expect(out.flags.second).to.equal('value')
+      })
+      
       it('parses short flags', async () => {
         const out = await parse(['-mf'], {
           flags: {


### PR DESCRIPTION
Spent some time diagnosing the issue that turned out to be from Willie's code 
[ca9fe38](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
Here's a fix to it that will enforce the prefixes "--" on the flag values and prevent his false positives, though I can see you reverted his commit already.  
Anyway, thought this might still be useful.  My scenario is reflected in the `parse.test.ts` unit test `doesn\'t throw when 2nd char in value matches a flag char` 