### PR TITLE
Wr/flag validation2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [2.8.11](https://github.com/oclif/core/compare/2.8.10...2.8.11) (2023-07-01)
+
+
+### Bug Fixes
+
+* **deps:** bump semver and @types/semver ([fe9f09f](https://github.com/oclif/core/commit/fe9f09f9e9ac301ea25116deca42d394b46f6f3e))
+
+
+
+## [2.8.10](https://github.com/oclif/core/compare/2.8.9...2.8.10) (2023-06-27)
+
+
+
 ## [2.8.9](https://github.com/oclif/core/compare/2.8.8...2.8.9) (2023-06-27)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oclif/core",
   "description": "base library for oclif CLIs",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/core/issues",
   "dependencies": {
@@ -24,7 +24,7 @@
     "natural-orderby": "^2.0.3",
     "object-treeify": "^1.1.33",
     "password-prompt": "^1.1.2",
-    "semver": "^7.3.7",
+    "semver": "^7.5.3",
     "string-width": "^4.2.3",
     "strip-ansi": "^6.0.1",
     "supports-color": "^8.1.1",
@@ -53,7 +53,7 @@
     "@types/node": "^16",
     "@types/node-notifier": "^8.0.2",
     "@types/proxyquire": "^1.3.28",
-    "@types/semver": "^7.3.13",
+    "@types/semver": "^7.5.0",
     "@types/shelljs": "^0.8.11",
     "@types/strip-ansi": "^5.2.1",
     "@types/supports-color": "^8.1.1",

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -86,7 +86,7 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
   public async parse(): Promise<ParserOutput<TFlags, BFlags, TArgs>> {
     this._debugInput()
 
-    const findLongFlag = (arg: string) => {
+    const findLongFlag = (arg: string):string | undefined => {
       const name = arg.slice(2)
       if (this.input.flags[name]) {
         return name
@@ -102,12 +102,12 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
       }
     }
 
-    const findShortFlag = ([_, char]: string) => {
+    const findShortFlag = ([_, char]: string):string | undefined => {
       if (this.flagAliases[char]) {
         return this.flagAliases[char].name
       }
 
-      return Object.keys(this.input.flags).find(k => this.input.flags[k].char === char)
+      return Object.keys(this.input.flags).find(k => (this.input.flags[k].char === char && char !== undefined && this.input.flags[k].char !== undefined))
     }
 
     const parseFlag = (arg: string): boolean => {
@@ -133,12 +133,13 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
       const flag = this.input.flags[name]
       if (flag.type === 'option') {
         this.currentFlag = flag
-        const input = long || arg.length < 3 ? this.argv.shift() : arg.slice(arg[2] === '=' ? 3 : 2)
-        if (typeof input !== 'string') {
+        const value = long || arg.length < 3 ? this.argv.shift()  : arg.slice(arg[2] === '=' ? 3 : 2)
+        // if the value ends up being one of the command's flags, the user didn't provide an input
+        if (typeof value !== 'string' || this.input.flags[findLongFlag(value) as string] || this.input.flags[findShortFlag(value) as string]) {
           throw new CLIError(`Flag --${name} expects a value`)
         }
 
-        this.raw.push({type: 'flag', flag: flag.name, input})
+        this.raw.push({type: 'flag', flag: flag.name, input: value})
       } else {
         this.raw.push({type: 'flag', flag: flag.name, input: arg})
         // push the rest of the short characters back on the stack

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -84,6 +84,58 @@ describe('parse', () => {
         expect(Boolean(out.flags.myflag2)).to.equal(true)
       })
 
+      it('throws error when no value provided to required flag', async () => {
+        try {
+          await parse(['--myflag', '--second', 'value'], {
+            flags: {myflag: Flags.string({required: true}), second: Flags.string()},
+          })
+        } catch (error) {
+          expect((error as CLIError).message).to.include('Flag --myflag expects a value')
+        }
+      })
+
+      it('throws error when no value provided to required short char flag', async () => {
+        try {
+          await parse(['--myflag', '-s', 'value'], {
+            flags: {myflag: Flags.string({required: true}), second: Flags.string({char: 's'})},
+          })
+        } catch (error) {
+          expect((error as CLIError).message).to.include('Flag --myflag expects a value')
+        }
+      })
+
+      it('doesn\'t throw when boolean flag passed', async () => {
+        const out =   await parse(['--myflag', '--second', 'value'], {
+          flags: {myflag: Flags.boolean(), second: Flags.string()},
+        })
+        expect(out.flags.myflag).to.be.true
+        expect(out.flags.second).to.equal('value')
+      })
+
+      it('doesn\'t throw when negative number passed', async () => {
+        const out =   await parse(['--myflag', '-s', '-9'], {
+          flags: {myflag: Flags.boolean(), second: Flags.integer({char: 's'})},
+        })
+        expect(out.flags.myflag).to.be.true
+        expect(out.flags.second).to.equal(-9)
+      })
+
+      it('doesn\'t throw when boolean short char is passed', async () => {
+        const out =   await parse(['--myflag', '-s', 'value'], {
+          flags: {myflag: Flags.boolean(), second: Flags.string({char: 's'})},
+        })
+        expect(out.flags.myflag).to.be.true
+        expect(out.flags.second).to.equal('value')
+      })
+
+      it('doesn\'t throw when  short char is passed as a string value', async () => {
+        const out =   await parse(['--myflag', '\'-s\'', '-s', 'value'], {
+          flags: {myflag: Flags.string(), second: Flags.string({char: 's'})},
+        })
+        expect(out.flags.myflag).to.equal('\'-s\'')
+        expect(out.flags.second).to.equal('value')
+      })
+
       it('parses short flags', async () => {
         const out = await parse(['-mf'], {
           flags: {

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -100,6 +100,7 @@ describe('parse', () => {
           await parse(['--myflag', '-s', 'value'], {
             flags: {myflag: Flags.string({required: true}), second: Flags.string({char: 's'})},
           })
+          assert.fail('should have thrown')
         } catch (error) {
           expect((error as CLIError).message).to.include('Flag --myflag expects a value')
         }

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -84,6 +84,22 @@ describe('parse', () => {
         expect(Boolean(out.flags.myflag2)).to.equal(true)
       })
 
+      it('doesn\'t throw when 2nd char in value matches a flag char', async () => {
+        const out =   await parse(['--myflag', 'Ishikawa', '-s', 'value'], {
+          flags: {myflag: Flags.string(), second: Flags.string({char: 's'})},
+        })
+        expect(out.flags.myflag).to.equal('Ishikawa')
+        expect(out.flags.second).to.equal('value')
+      })
+
+      it('doesn\'t throw when an unprefixed flag value contains a flag name', async () => {
+        const out =   await parse(['--myflag', 'a-second-place-finish', '-s', 'value'], {
+          flags: {myflag: Flags.string(), second: Flags.string({char: 's'})},
+        })
+        expect(out.flags.myflag).to.equal('a-second-place-finish')
+        expect(out.flags.second).to.equal('value')
+      })
+
       it('throws error when no value provided to required flag', async () => {
         try {
           await parse(['--myflag', '--second', 'value'], {

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -89,12 +89,13 @@ describe('parse', () => {
           await parse(['--myflag', '--second', 'value'], {
             flags: {myflag: Flags.string({required: true}), second: Flags.string()},
           })
+          assert.fail('should have thrown')
         } catch (error) {
           expect((error as CLIError).message).to.include('Flag --myflag expects a value')
         }
       })
 
-      it('throws error when no value provided to required short char flag', async () => {
+      it('throws error when no value provided to required flag before a short char flag', async () => {
         try {
           await parse(['--myflag', '-s', 'value'], {
             flags: {myflag: Flags.string({required: true}), second: Flags.string({char: 's'})},

--- a/yarn.lock
+++ b/yarn.lock
@@ -702,10 +702,10 @@
   resolved "https://registry.yarnpkg.com/@types/proxyquire/-/proxyquire-1.3.28.tgz#05a647bb0d8fe48fc8edcc193e43cc79310faa7d"
   integrity sha512-SQaNzWQ2YZSr7FqAyPPiA3FYpux2Lqh3HWMZQk47x3xbMCqgC/w0dY3dw9rGqlweDDkrySQBcaScXWeR+Yb11Q==
 
-"@types/semver@^7.3.13":
-  version "7.3.13"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
-  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+"@types/semver@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
+  integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
 
 "@types/shelljs@^0.8.11":
   version "0.8.11"
@@ -2932,10 +2932,10 @@ semver@^6.1.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.0:
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.0.tgz#ed8c5dc8efb6c629c88b23d41dc9bf40c1d96cd0"
-  integrity sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==
+semver@^7.2.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.0, semver@^7.5.3:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
+  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
@W-13157931@

improves flag validation to prevent a flag being read as a flag value

the NUTs should fail and catch the bug that this introduced [cecd7c7](https://github.com/oclif/core/pull/725/commits/cecd7c775ddef217f8025181eb555a9aab8f2e07)

and now with the latest commit, they should pass [410090c](https://github.com/oclif/core/pull/725/commits/410090c44195b818e835e9fc658cf9db8c70b8f0)