### PR TITLE
Sm/perf-gains

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@oclif/plugin-plugins": "^2.4.7",
     "@oclif/test": "^2.3.15",
     "@types/ansi-styles": "^3.2.1",
+    "@types/benchmark": "^2.1.2",
     "@types/chai": "^4.3.4",
     "@types/chai-as-promised": "^7.1.5",
     "@types/clean-stack": "^2.1.1",
@@ -59,6 +60,7 @@
     "@types/supports-color": "^8.1.1",
     "@types/wordwrap": "^1.0.1",
     "@types/wrap-ansi": "^3.0.0",
+    "benchmark": "^2.1.4",
     "chai": "^4.3.7",
     "chai-as-promised": "^7.1.1",
     "commitlint": "^12.1.4",
@@ -111,7 +113,8 @@
     "prepack": "yarn run build",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
     "test:e2e": "mocha --forbid-only \"test/**/*.e2e.ts\" --timeout 1200000",
-    "pretest": "yarn build --noEmit && tsc -p test --noEmit --skipLibCheck"
+    "pretest": "yarn build --noEmit && tsc -p test --noEmit --skipLibCheck",
+    "test:perf": "ts-node test/perf/parser.perf.ts"
   },
   "types": "lib/index.d.ts"
 }

--- a/perf.txt
+++ b/perf.txt
@@ -1,6 +1,6 @@
 yarn run v1.22.19
 $ ts-node test/perf/parser.perf.ts
-simple x 103,392 ops/sec ±0.91% (77 runs sampled)
-multiple async flags that take time x 4.96 ops/sec ±0.13% (28 runs sampled)
-multiple async flags that take time x 5,451 ops/sec ±2.09% (79 runs sampled)
-Done in 21.11s.
+simple x 131,268 ops/sec ±1.15% (79 runs sampled)
+multiple async flags that take time x 9.90 ops/sec ±0.14% (50 runs sampled)
+flagstravaganza x 7,425 ops/sec ±2.10% (83 runs sampled)
+Done in 21.60s.

--- a/perf.txt
+++ b/perf.txt
@@ -1,0 +1,6 @@
+yarn run v1.22.19
+$ ts-node test/perf/parser.perf.ts
+simple x 103,392 ops/sec ±0.91% (77 runs sampled)
+multiple async flags that take time x 4.96 ops/sec ±0.13% (28 runs sampled)
+multiple async flags that take time x 5,451 ops/sec ±2.09% (79 runs sampled)
+Done in 21.11s.

--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -41,7 +41,7 @@ export type Metadata = {
   flags: { [key: string]: MetadataFlag };
 }
 
-type MetadataFlag = {
+export type MetadataFlag = {
   setFromDefault?: boolean;
   defaultHelp?: unknown;
 }

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -310,8 +310,6 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
       ctx.token = token
 
       if (flag.type === 'boolean') {
-        const ctx = this.context
-        ctx.token = token
         return await flag.parse(input, ctx, flag)
       }
 

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -275,7 +275,7 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
       // no input: env flags
       if (fws.inputFlag.flag.env && process.env[fws.inputFlag.flag.env]) {
         const valueFromEnv = process.env[fws.inputFlag.flag.env]
-        if (fws.inputFlag.flag.type === 'option' && typeof valueFromEnv === 'string') {
+        if (fws.inputFlag.flag.type === 'option' && valueFromEnv) {
           return {...fws, valueFunction: async (i: FlagWithStrategy) => parseFlagOrThrowError(validateOptions(i.inputFlag.flag as OptionFlag<any>, valueFromEnv), i.inputFlag.flag, this.context)}
         }
 

--- a/test/perf/parser.perf.ts
+++ b/test/perf/parser.perf.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {Suite} from 'benchmark'
+import {parse} from '../../src/parser'
+import {Flags} from '../../src'
+
+const suite = new Suite()
+
+// eslint-disable-next-line no-promise-executor-return
+const delay100 = () => new Promise(resolve => setTimeout(resolve, 100))
+
+suite
+.add('simple',
+  {
+    defer: true,
+    fn: function (deferred: { resolve: () => any }) {
+      parse(['--bool'], {
+        flags: {
+          bool: Flags.boolean(),
+        },
+      }).then(() => deferred.resolve())
+    },
+  })
+.add('multiple async flags that take time', {
+  defer: true,
+  fn: function (deferred: { resolve: () => any }) {
+    parse(['--flagA', 'foo', '--flagA', 'bar'], {
+      flags: {
+        flagA: Flags.string({
+          parse: async input => {
+            await delay100()
+            return input
+          },
+        }),
+        flagB: Flags.string({
+          parse: async input => {
+            await delay100()
+            return input
+          },
+        }),
+      },
+    }).then(() => deferred.resolve())
+  },
+})
+
+.add('flagstravaganza', {
+  defer: true,
+  fn: function (deferred: { resolve: () => any }) {
+    const flags = [
+      ['--bool'],
+      ['-S', 'foo'],
+
+      ['--dep-string', 'foo'],
+      ['--excl-string', 'foo'],
+      ['--exactly-one', 'foo'],
+
+      ['--parsed-string-as-number', '5'],
+      ['--dir', process.cwd()],
+      ['--file', __filename],
+
+      ['--multiple', '1'],
+      ['--multiple', '2'],
+      ['--multiple', '3'],
+      ['--multiple2', '5,6,7,8,9,10,11'],
+    ]
+    const exactlyOne = ['exactly-one-nope', 'exactly-one-nope2', 'exactly-one']
+    parse(flags.flat(), {
+      flags: {
+        bool: Flags.boolean(),
+        string: Flags.string({char: 's', aliases: ['S']}),
+
+        'dep-string': Flags.string({dependsOn: ['string']}),
+        // don't populate this one, used for exclusive test
+        nope: Flags.boolean(),
+        'excl-string': Flags.string({exclusive: ['nope']}),
+        'exactly-one-nope': Flags.string({exactlyOne}),
+        'exactly-one-nope2': Flags.string({exactlyOne}),
+        'exactly-one': Flags.string({exactlyOne}),
+
+        'parsed-string-as-number': Flags.integer({parse: input => Promise.resolve(Number.parseInt(input, 10) + 1000)}),
+        dir: Flags.directory({exists: true}),
+        file: Flags.file({exists: true}),
+
+        multiple: Flags.string({multiple: true}),
+        multiple2: Flags.string({multiple: true, delimiter: ','}),
+      },
+    }).then(() => deferred.resolve())
+  },
+})
+
+// add listeners
+.on('cycle', (event: any) => {
+  console.log(String(event.target))
+})
+.run({async: true})

--- a/yarn.lock
+++ b/yarn.lock
@@ -567,6 +567,11 @@
   dependencies:
     "@types/color-name" "*"
 
+"@types/benchmark@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@types/benchmark/-/benchmark-2.1.2.tgz#b7838408c93dc08ceb4e6e13147dbfbe6a151f82"
+  integrity sha512-EDKtLYNMKrig22jEvhXq8TBFyFgVNSPmDF2b9UzJ7+eylPqdZVo17PCUMkn1jP6/1A/0u78VqYC6VrX6b8pDWA==
+
 "@types/chai-as-promised@^7.1.5":
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz#6e016811f6c7a64f2eed823191c3a6955094e255"
@@ -981,6 +986,14 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+benchmark@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
+  integrity sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==
+  dependencies:
+    lodash "^4.17.4"
+    platform "^1.3.3"
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -2300,7 +2313,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
+lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2708,6 +2721,11 @@ pify@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
+platform@^1.3.3:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
+  integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
 plur@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
rewrite of Parse and Validate (flags only, not args)
 
this branch:
$ ts-node test/perf/parser.perf.ts
simple x 131,268 ops/sec ±1.15% (79 runs sampled)
**multiple async flags that take time x 9.90 ops/sec ±0.14% (50 runs sampled)**
flagstravaganza x 7,425 ops/sec ±2.10% (83 runs sampled)

main
$ ts-node test/perf/parser.perf.ts
simple x 103,392 ops/sec ±0.91% (77 runs sampled)
**multiple async flags that take time x 4.96 ops/sec ±0.13% (28 runs sampled)**
multiple async flags that take time x 5,451 ops/sec ±2.09% (79 runs sampled)

lots of refactoring was needed to enable parallelization, but the main goal is to run flags' async parse methods in parallel.

The code could be a lot cleaner if we could make the assumption that this.context on Parser is not mutating.

That middle perf test `multiple async flags that take time` is meant to model something that's got some delay on it (ex, various local fs operations like sf's Org flag)