### PR TITLE
fix: flags omit undefined for boolean flags

### DIFF
--- a/perf.txt
+++ b/perf.txt
@@ -1,6 +1,0 @@
-yarn run v1.22.19
-$ ts-node test/perf/parser.perf.ts
-simple x 131,268 ops/sec ±1.15% (79 runs sampled)
-multiple async flags that take time x 9.90 ops/sec ±0.14% (50 runs sampled)
-flagstravaganza x 7,425 ops/sec ±2.10% (83 runs sampled)
-Done in 21.60s.

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -346,8 +346,9 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
 
     const valueReference = fwsArrayToObject(flagsWithValues.filter(fws => !fws.metadata?.setFromDefault))
 
-    const flagsWithAllValues = await Promise.all(flagsWithValues
+    const flagsWithAllValues = (await Promise.all(flagsWithValues
     .map(async fws => (fws.metadata?.setFromDefault ? {...fws, value: await fws.valueFunction?.(fws, valueReference)} : fws)))
+    ).filter(fws => fws.value !== undefined)
 
     const finalFlags = (flagsWithAllValues.some(fws => typeof fws.helpFunction === 'function')) ? await addDefaultHelp(flagsWithAllValues) : flagsWithAllValues
 

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -317,7 +317,10 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
       return Promise.all(fws.map(async fws => fws.helpFunction ? ({...fws, metadata: {...fws.metadata, defaultHelp: await fws.helpFunction?.(fws, valueReferenceForHelp, this.context)}}) : fws))
     }
 
-    const fwsArrayToObject = (fwsArray: FlagWithStrategy[]) => Object.fromEntries(fwsArray.map(fws => [fws.inputFlag.name, fws.value]))
+    const fwsArrayToObject = (fwsArray: FlagWithStrategy[]) => Object.fromEntries(
+      fwsArray.filter(fws => fws.value !== undefined)
+      .map(fws => [fws.inputFlag.name, fws.value]),
+    )
 
     type FlagWithStrategy = {
       inputFlag: {
@@ -346,9 +349,8 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
 
     const valueReference = fwsArrayToObject(flagsWithValues.filter(fws => !fws.metadata?.setFromDefault))
 
-    const flagsWithAllValues = (await Promise.all(flagsWithValues
+    const flagsWithAllValues = await Promise.all(flagsWithValues
     .map(async fws => (fws.metadata?.setFromDefault ? {...fws, value: await fws.valueFunction?.(fws, valueReference)} : fws)))
-    ).filter(fws => fws.value !== undefined)
 
     const finalFlags = (flagsWithAllValues.some(fws => typeof fws.helpFunction === 'function')) ? await addDefaultHelp(flagsWithAllValues) : flagsWithAllValues
 

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -22,6 +22,29 @@ describe('parse', () => {
     expect(out).to.deep.include({flags: {bool: true}})
   })
 
+  describe('undefined flags', () => {
+    it('omits undefined flags when no flags', async () => {
+      const out = await parse([], {
+        flags: {
+          bool: Flags.boolean(),
+        },
+      })
+      expect(out.flags).to.deep.equal({})
+    })
+
+    it('omits undefined flags when some flags exist', async () => {
+      const out = await parse(['--bool', '--str', 'k'], {
+        flags: {
+          bool: Flags.boolean(),
+          bool2: Flags.boolean(),
+          str: Flags.string(),
+          str2: Flags.string(),
+        },
+      })
+      expect(out.flags).to.deep.equal({bool: true, str: 'k'})
+    })
+  })
+
   it('arg1', async () => {
     const out = await parse(['arg1'], {
       args: {foo: Args.string()},


### PR DESCRIPTION
fix https://github.com/oclif/core/issues/729

[boolean flags have a built-in `parse` function even if the user doesn't specify it.  It was easier to filter out `undefined` flags after calculating all the valus than to try to interfere with boolean flags before the `default` logic happens]