### PR TITLE
fix(parser): don't throw if defaultHelp func throws

### DIFF
--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -314,7 +314,23 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
 
     const addDefaultHelp = async (fws: FlagWithStrategy[]): Promise<FlagWithStrategy[]> => {
       const valueReferenceForHelp = fwsArrayToObject(flagsWithAllValues.filter(fws => !fws.metadata?.setFromDefault))
-      return Promise.all(fws.map(async fws => fws.helpFunction ? ({...fws, metadata: {...fws.metadata, defaultHelp: await fws.helpFunction?.(fws, valueReferenceForHelp, this.context)}}) : fws))
+      return Promise.all(fws.map(async fws => {
+        try {
+          if (fws.helpFunction) {
+            return {
+              ...fws,
+              metadata: {
+                ...fws.metadata,
+                defaultHelp: await fws.helpFunction?.(fws, valueReferenceForHelp, this.context),
+              },
+            }
+          }
+        } catch {
+          // no-op
+        }
+
+        return fws
+      }))
     }
 
     const fwsArrayToObject = (fwsArray: FlagWithStrategy[]) => Object.fromEntries(

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -106,6 +106,18 @@ describe('parse', () => {
         expect(Boolean(out.flags.myflag)).to.equal(true)
         expect(Boolean(out.flags.myflag2)).to.equal(true)
       })
+      it('doesn\' throw if defaultHelp func fails', async () => {
+        const out = await parse(['--foo', 'baz'], {
+          flags: {
+            foo: Flags.custom({
+              defaultHelp: async () => {
+                throw new Error('failed to get default help value')
+              },
+            })(),
+          },
+        })
+        expect(out.flags.foo).to.equal('baz')
+      })
 
       it('doesn\'t throw when 2nd char in value matches a flag char', async () => {
         const out =   await parse(['--myflag', 'Ishikawa', '-s', 'value'], {


### PR DESCRIPTION
Fixes regression in flag parser, see:
https://github.com/salesforcecli/plugin-deploy-retrieve/actions/runs/5532397529/jobs/10094675376

the previous implementation would keep parsing flags even if `flag.defaultHelp()` throws.

deploy NUTs in PDR caught this because testkit creates a scratch org without setting it as a local default (`-d/--set-default`):
https://github.com/salesforcecli/cli-plugins-testkit/blob/a5b31a8fe107faa14184b0777852b161dfdf0d3f/src/testSession.ts#L343

then when trying to delete the scratch org with `org delete scratch`, oclif throws this err while parsing flags:
```
Error (1): Unable to determine the username of the org to delete. Specify the username with the --target-org | -o flag.
```

because `defaultHelp` doesn't pass any arg to `resolveUsername`:
https://github.com/salesforcecli/plugin-org/blob/4d49015ad1d94699d4ac40a8610036b5ff08dbf2/src/shared/flags.ts#L38
https://github.com/salesforcecli/plugin-org/blob/4d49015ad1d94699d4ac40a8610036b5ff08dbf2/src/shared/flags.ts#L22


#### repro with `sf`
0) install current `sf` nightly, this includes latest oclif/core
`npm i -g @salesforce/cli@nightly`
1) `cd dreamhouse-lwc`
2) create scratch org but don't set it as a default:
`sf org create scratch -f config/project-scratch-def.json -a dreamhouse --duration-days 1 --target-dev-hub na40`
3) try to delete it:
`sf org delete scratch -o dreamhouse -p`

you should see:
```
➜  dreamhouse-lwc git:(main) sf org delete scratch -o dreamhouse -p
Error (1): Unable to determine the username of the org to delete. Specify the username with the --target-org | -o flag.
```