### PR TITLE
Allow empty flag default

### DIFF
--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -351,10 +351,9 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
     }
 
     const flagTokenMap = this.mapAndValidateFlags()
-
     const flagsWithValues = await Promise.all(Object.entries(this.input.flags)
     // we check them if they have a token, or might have env, default, or defaultHelp.  Also include booleans so they get their default value
-    .filter(([name, flag]) => flag.type === 'boolean' || flag.env || flag.default || 'defaultHelp' in flag || flagTokenMap.has(name))
+    .filter(([name, flag]) => flag.type === 'boolean' || flag.env || flag.default !== undefined || 'defaultHelp' in flag || flagTokenMap.has(name))
     // match each possible flag to its token, if there is one
     .map(([name, flag]): FlagWithStrategy => ({inputFlag: {name, flag}, tokens: flagTokenMap.get(name)}))
     .map(fws => addValueFunction(fws))

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -974,11 +974,19 @@ See more help with --help`)
     it('accepts falsy flags', async () => {
       const out = await parse([], {
         flags: {
-          foo: Flags.string({default: ''}),
+          foo1: Flags.string({default: ''}),
+          foo2: Flags.string({default: '0'}),
+          foo3: Flags.string({default: 'false'}),
+          foo4: Flags.string({default: 'undefined'}),
+          bar: Flags.integer({default: 0}),
           baz: Flags.boolean({default: false}),
         },
       })
-      expect(out.flags).to.deep.include({foo: ''})
+      expect(out.flags).to.deep.include({foo1: ''})
+      expect(out.flags).to.deep.include({foo2: '0'})
+      expect(out.flags).to.deep.include({foo3: 'false'})
+      expect(out.flags).to.deep.include({foo4: 'undefined'})
+      expect(out.flags).to.deep.include({bar: 0})
       expect(out.flags).to.deep.include({baz: false})
     })
 

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -971,6 +971,17 @@ See more help with --help`)
       expect(out.args).to.deep.include({baz: false})
     })
 
+    it('accepts falsy flags', async () => {
+      const out = await parse([], {
+        flags: {
+          foo: Flags.string({default: ''}),
+          baz: Flags.boolean({default: false}),
+        },
+      })
+      expect(out.flags).to.deep.include({foo: ''})
+      expect(out.flags).to.deep.include({baz: false})
+    })
+
     it('default as function', async () => {
       const out = await parse([], {
         args: {baz: Args.string({default: async () => 'BAZ'})},


### PR DESCRIPTION
Allow an empty string as a flag default. Used in a few places and caused NUTs to fail
https://github.com/salesforcecli/plugin-community/blob/main/src/commands/community/create.ts#L60
https://github.com/salesforcecli/plugin-custom-metadata/blob/main/src/commands/cmdt/generate/object.ts#L64

[@W-13754930@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-13754930)