### PR TITLE
fix: support node 14 again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,23 @@ jobs:
   windows-unit-tests:
     needs: linux-unit-tests
     uses: salesforcecli/github-workflows/.github/workflows/unitTestsWindows.yml@main
+  node14:
+    needs: linux-unit-tests
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "windows-latest"]
+        node_version: [14.x]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: yarn
+      - run: yarn install
+      - run: yarn build
+      - run: yarn test
   e2e:
     needs: linux-unit-tests
     strategy:

--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -287,7 +287,7 @@ export type BooleanFlag<T> = FlagProps & BooleanFlagProps & {
    * specifying a default of false is the same as not specifying a default
    */
   default?: FlagDefault<boolean>;
-  parse: (input: boolean, context: Command, opts: FlagProps & BooleanFlagProps) => Promise<T>
+  parse: (input: boolean, context: FlagParserContext, opts: FlagProps & BooleanFlagProps) => Promise<T>
 }
 
 export type OptionFlagDefaults<T, P = CustomOptions, M = false> = FlagProps & OptionFlagProps & {
@@ -325,7 +325,7 @@ export type Input<TFlags extends FlagOutput, BFlags extends FlagOutput, AFlags e
   baseFlags?: FlagInput<BFlags>;
   args?: ArgInput<AFlags>;
   strict?: boolean;
-  context?: Command;
+  context?: ParserContext;
   '--'?: boolean;
 }
 
@@ -334,8 +334,12 @@ export type ParserInput = {
   flags: FlagInput<any>;
   args: ArgInput<any>;
   strict: boolean;
-  context: Command | undefined;
+  context: ParserContext | undefined;
   '--'?: boolean;
+}
+
+export type ParserContext = Command & {
+  token?: FlagToken | ArgToken;
 }
 
 export type CompletionContext = {

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -258,12 +258,14 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
     const parseFlagOrThrowError = async (input: any, flag: BooleanFlag<any> | OptionFlag<any>, token?: FlagToken, context: typeof this.context = {}) => {
       if (!flag.parse) return input
 
+      context.flag = flag
+
       try {
         if (flag.type === 'boolean') {
-          return await flag.parse(input, {...context, token}, flag)
+          return await flag.parse(input, context, flag)
         }
 
-        return await flag.parse(input, {...context, token}, flag)
+        return await flag.parse(input, context, flag)
       } catch (error: any) {
         error.message = `Parsing --${flag.name} \n\t${error.message}\nSee more help with --help`
         throw error

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -2,7 +2,7 @@
 import {ArgInvalidOptionError, CLIError, FlagInvalidOptionError} from './errors'
 import {ArgToken, BooleanFlag, CompletableFlag, FlagToken, Metadata, MetadataFlag, OptionFlag, OutputArgs, OutputFlags, ParserInput, ParserOutput, ParsingToken} from '../interfaces/parser'
 import * as readline from 'readline'
-import {isTruthy, pickBy} from '../util'
+import {isTruthy, last, pickBy} from '../util'
 
 let debug: any
 try {
@@ -245,8 +245,8 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
       // user provided some input
       if (tokenLength) {
         // boolean
-        if (fws.inputFlag.flag.type === 'boolean' && fws.tokens?.at(-1)?.input) {
-          return {...fws, valueFunction: async (i: FlagWithStrategy) => parseFlagOrThrowError(i.tokens?.at(-1)?.input !== `--no-${i.inputFlag.name}`, i.inputFlag.flag, i.tokens?.at(-1), this.context)}
+        if (fws.inputFlag.flag.type === 'boolean' && last(fws.tokens)?.input) {
+          return {...fws, valueFunction: async (i: FlagWithStrategy) => parseFlagOrThrowError(last(i.tokens)?.input !== `--no-${i.inputFlag.name}`, i.inputFlag.flag, last(i.tokens), this.context)}
         }
 
         // multiple with custom delimiter
@@ -256,7 +256,7 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
               ((i.tokens ?? []).flatMap(token => (token.input as string).split(i.inputFlag.flag.delimiter as string)))
               // trim, and remove surrounding doubleQuotes (which would hav been needed if the elements contain spaces)
               .map(v => v.trim().replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1'))
-              .map(async v => parseFlagOrThrowError(v, i.inputFlag.flag, {...i.tokens?.at(-1) as FlagToken, input: v}, this.context)),
+              .map(async v => parseFlagOrThrowError(v, i.inputFlag.flag, {...last(i.tokens) as FlagToken, input: v}, this.context)),
             )).map(v => validateOptions(i.inputFlag.flag as OptionFlag<any>, v)),
           }
         }
@@ -268,7 +268,7 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
 
         // simple option flag
         if (fws.inputFlag.flag.type === 'option') {
-          return {...fws, valueFunction: async (i: FlagWithStrategy) => parseFlagOrThrowError(validateOptions(i.inputFlag.flag as OptionFlag<any>, fws.tokens?.at(-1)?.input as string), i.inputFlag.flag, fws.tokens?.at(-1), this.context)}
+          return {...fws, valueFunction: async (i: FlagWithStrategy) => parseFlagOrThrowError(validateOptions(i.inputFlag.flag as OptionFlag<any>, last(fws.tokens)?.input as string), i.inputFlag.flag, last(fws.tokens), this.context)}
         }
       }
 

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -258,7 +258,7 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
     const parseFlagOrThrowError = async (input: any, flag: BooleanFlag<any> | OptionFlag<any>, token?: FlagToken, context: typeof this.context = {}) => {
       if (!flag.parse) return input
 
-      context.flag = flag
+      context.token = token
 
       try {
         if (flag.type === 'boolean') {

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,6 +22,11 @@ export function uniqBy<T>(arr: T[], fn: (cur: T) => any): T[] {
   })
 }
 
+export function last<T>(arr?: T[]): T | undefined {
+  if (!arr) return
+  return arr.slice(-1)[0]
+}
+
 type SortTypes = string | number | undefined | boolean
 
 export function sortBy<T>(arr: T[], fn: (i: T) => SortTypes | SortTypes[]): T[] {

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai'
-import {maxBy, sumBy, capitalize, ensureArgObject} from '../src/util'
+import {maxBy, sumBy, capitalize, ensureArgObject, last} from '../src/util'
 
 describe('capitalize', () => {
   it('capitalizes the string', () => {
@@ -31,6 +31,22 @@ describe('maxBy', () => {
   it('returns max value in the array', () => {
     const arr: Item[] = [{x: 1}, {x: 3}, {x: 2}]
     expect(maxBy(arr, i => i.x)).to.equal(arr[1])
+  })
+})
+
+describe('last', () => {
+  it('returns undefined for empty array', () => {
+    expect(last([])).to.be.undefined
+  })
+  it('returns undefined for undefined', () => {
+    expect(last()).to.be.undefined
+  })
+  it('returns last value in the array', () => {
+    const arr: Item[] = [{x: 1}, {x: 3}, {x: 2}]
+    expect(last(arr)).to.equal(arr[2])
+  })
+  it('returns only item in array', () => {
+    expect(last([6])).to.equal(6)
   })
 })
 


### PR DESCRIPTION
- Reverts use of `Array.at` to ensure Node 14 compatibility
  - Fixes #731 
  - Fixes https://github.com/oclif/plugin-plugins/issues/624)
- Adds back support for reading flag values from stdin in Node 14 (See JSDoc on `readStdinLegacy` to understand the drawbacks of keeping this in)
  - Fixes #630
  - Fixes https://github.com/oclif/oclif/issues/1106
- Fixes regression with `Flags.help` and `Flags.version`
  - Fixes #740




