### PR TITLE
fix: corrected return type for Command.exit (#715)

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -242,8 +242,8 @@ export abstract class Command {
     return result as T
   }
 
-  public exit(code = 0): void {
-    return Errors.exit(code)
+  public exit(code = 0): never {
+    Errors.exit(code)
   }
 
   public warn(input: string | Error): string | Error {


### PR DESCRIPTION
Merges #715 
Fixes #714 