### PR TITLE
Sm/parallelize-plugin-loading

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
           cache: yarn
-      - run: yarn install
+      - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
       - run: yarn build
       - run: yarn test
   e2e:
@@ -49,7 +49,7 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
           cache: yarn
-      - run: yarn install --network-timeout 600000
+      - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
       - run: yarn build
       - run: yarn test:e2e
   nuts:

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -607,18 +607,9 @@ export class Config implements IConfig {
           opts.root = plugin.root || opts.root
         }
 
-        const pluginMarker = Performance.mark(`plugin.load#${opts.name!}`)
         const instance = new Plugin.Plugin(opts)
         await instance.load()
-        pluginMarker?.addDetails({
-          hasManifest: instance.hasManifest,
-          commandCount: instance.commands.length,
-          topicCount: instance.topics.length,
-          type: instance.type,
-          usesMain: Boolean(instance.pjson.main),
-          name: instance.name,
-        })
-        pluginMarker?.stop()
+
         if (this.plugins.find(p => p.name === instance.name)) return
         this.plugins.push(instance)
         if (parent) {

--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -143,6 +143,8 @@ export class Plugin implements IPlugin {
    * @returns Promise<void>
    */
   public async load(isWritingManifest?: boolean): Promise<void> {
+    const pluginMarker = Performance.mark(`plugin.load#${this.options.name!}`)
+
     this.type = this.options.type || 'core'
     this.tag = this.options.tag
     const root = await findRoot(this.options.name, this.options.root)
@@ -176,6 +178,15 @@ export class Plugin implements IPlugin {
       load: async () => this.findCommand(id, {must: true}),
     }))
     .sort((a, b) => a.id.localeCompare(b.id))
+    pluginMarker?.addDetails({
+      hasManifest: this.hasManifest,
+      commandCount: this.commands.length,
+      topicCount: this.topics.length,
+      type: this.type,
+      usesMain: Boolean(this.pjson.main),
+      name: this.name,
+    })
+    pluginMarker?.stop()
   }
 
   public get topics(): Topic[] {


### PR DESCRIPTION
current: for all plugins, in parallel, run the hooks for each plugin sequentially

change: do all the hooks for all plugins in parallel

## other

- move per-plugin load Perf marking to the Plugin:load function instead of Config.
- yarn install retries like salesforce repos use