### PR TITLE
fix: use configured help class in --help

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,5 +1,5 @@
 import {URL} from 'url'
-import {Help} from './help'
+import {loadHelpClass} from './help'
 import {BooleanFlag} from './interfaces'
 import {FlagDefinition, OptionFlagDefaults, FlagParser} from './interfaces/parser'
 import {dirExists, fileExists} from './util'
@@ -114,7 +114,8 @@ export const help = (opts: Partial<BooleanFlag<boolean>> = {}): BooleanFlag<void
     description: 'Show CLI help.',
     ...opts,
     parse: async (_, cmd) => {
-      new Help(cmd.config).showHelp(cmd.id ? [cmd.id, ...cmd.argv] : cmd.argv)
+      const Help = await loadHelpClass(cmd.config)
+      await new Help(cmd.config, cmd.config.pjson.helpOptions).showHelp(cmd.id ? [cmd.id, ...cmd.argv] : cmd.argv)
       cmd.exit(0)
     },
   })


### PR DESCRIPTION
without this change `my-cli command --help` always uses the default help class.