### PR TITLE
feat: reload Config before running command

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -223,6 +223,7 @@ export abstract class Command {
   }
 
   protected async _run<T>(): Promise<T> {
+    await this.reloadConfig(this.config)
     let err: Error | undefined
     let result: T | undefined
     try {
@@ -401,6 +402,23 @@ export abstract class Command {
     }
 
     keys.map(key => delete process.env[key])
+  }
+
+  /**
+   * Reload the Config based on the version required by the command.
+   * This is needed because the command is given the Config instantiated
+   * by the root plugin, which may be a different version than the one
+   * required by the command.
+   *
+   * Doing this ensures that the command can freely use any method on Config that
+   * exists in the version of Config required by the command but may not exist on the
+   * root's instance of Config.
+   *
+   * @param config The Config to reload.
+   * @returns void
+   */
+  private async reloadConfig(config: Config): Promise<void> {
+    this.config = await Config.load(config, true)
   }
 }
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -223,7 +223,6 @@ export abstract class Command {
   }
 
   protected async _run<T>(): Promise<T> {
-    await this.reloadConfig(this.config)
     let err: Error | undefined
     let result: T | undefined
     try {
@@ -402,23 +401,6 @@ export abstract class Command {
     }
 
     keys.map(key => delete process.env[key])
-  }
-
-  /**
-   * Reload the Config based on the version required by the command.
-   * This is needed because the command is given the Config instantiated
-   * by the root plugin, which may be a different version than the one
-   * required by the command.
-   *
-   * Doing this ensures that the command can freely use any method on Config that
-   * exists in the version of Config required by the command but may not exist on the
-   * root's instance of Config.
-   *
-   * @param config The Config to reload.
-   * @returns void
-   */
-  private async reloadConfig(config: Config): Promise<void> {
-    this.config = await Config.load(config, true)
   }
 }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -113,7 +113,9 @@ export class Config implements IConfig {
 
   private _commandIDs!: string[]
 
-  constructor(public options: Options) {}
+  constructor(public options: Options) {
+    if (options.config) Object.assign(this, options.config)
+  }
 
   static async load(opts: LoadOptions = module.filename || __dirname): Promise<Config> {
     // Handle the case when a file URL string is passed in such as 'import.meta.url'; covert to file path.
@@ -137,9 +139,7 @@ export class Config implements IConfig {
        */
       if (lt(incomingConfigBase, currentConfigBase)) {
         debug(`reloading config from ${opts._base} to ${BASE}`)
-        const config = new Config({...opts.options, config: opts})
-        await config.load()
-        return config
+        return new Config({...opts.options, config: opts})
       }
 
       return opts
@@ -152,10 +152,7 @@ export class Config implements IConfig {
 
   // eslint-disable-next-line complexity
   public async load(): Promise<void> {
-    if (this.options.config) {
-      Object.assign(this, this.options.config)
-      return
-    }
+    if (this.options.config) return
 
     settings.performanceEnabled = (settings.performanceEnabled === undefined ? this.options.enablePerf : settings.performanceEnabled) ?? false
     const plugin = new Plugin.Plugin({root: this.options.root})

--- a/src/interfaces/plugin.ts
+++ b/src/interfaces/plugin.ts
@@ -1,3 +1,4 @@
+import {Config} from './config'
 import {Command} from '../command'
 import {PJSON} from './pjson'
 import {Topic} from './topic'
@@ -20,6 +21,7 @@ export interface Options extends PluginOptions {
   channel?: string;
   version?: string;
   enablePerf?: boolean;
+  config?: Config
 }
 
 export interface Plugin {


### PR DESCRIPTION
Proof of concept for fixing `Config` mismatch issue described [here](https://github.com/forcedotcom/cli/issues/2426#issuecomment-1693415044)

```
$ sf update -v 2.5.7
$ cd plugin-plugins
$ sf plugins link
$ sf plugins --core
    TypeError: this.config.getPluginsList is not a function
$ yarn link @oclif/ocre
$ sf plugins --core
@oclif/plugin-autocomplete 2.3.6 (core)
@oclif/plugin-commands 2.2.22 (core)
@oclif/plugin-help 5.2.17 (core)
@oclif/plugin-not-found 2.3.37 (core)
@oclif/plugin-plugins 3.3.0 (link) /Users/mdonnalley/repos/oclif/plugin-plugins
@oclif/plugin-search 0.0.22 (core)
@oclif/plugin-update 3.1.32 (core)
@oclif/plugin-version 1.3.8 (core)
@oclif/plugin-warn-if-update-available 2.0.48 (core)
@oclif/plugin-which 2.2.30 (core)
@salesforce/cli 2.5.7 (core)
apex 2.3.10 (core)
auth 2.8.12 (core)
data 2.5.6 (core)
deploy-retrieve 1.17.5 (core)
info 2.6.39 (core)
limits 2.3.30 (core)
login 1.2.26 (core)
org 2.10.0 (core)
schema 2.3.23 (core)
settings 1.4.25 (core)
sobject 0.2.4 (core)
source 2.10.31 (core)
telemetry 2.3.0 (core)
templates 55.5.10 (core)
trust 2.6.1 (core)
user 2.3.28 (core)
```