### PR TITLE
feat: add noCacheDefault

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -911,6 +911,7 @@ export async function toCached(c: Command.Class, plugin?: IPlugin | undefined, i
         deprecateAliases: c.deprecateAliases,
         aliases: flag.aliases,
         delimiter: flag.delimiter,
+        noCacheDefault: flag.noCacheDefault,
       }
     } else {
       flags[name] = {
@@ -934,6 +935,7 @@ export async function toCached(c: Command.Class, plugin?: IPlugin | undefined, i
         deprecateAliases: c.deprecateAliases,
         aliases: flag.aliases,
         delimiter: flag.delimiter,
+        noCacheDefault: flag.noCacheDefault,
       }
       // a command-level placeholder in the manifest so that oclif knows it should regenerate the command during help-time
       if (typeof flag.defaultHelp === 'function') {
@@ -951,6 +953,7 @@ export async function toCached(c: Command.Class, plugin?: IPlugin | undefined, i
       options: arg.options,
       default: await defaultArgToCached(arg, isWritingManifest),
       hidden: arg.hidden,
+      noCacheDefault: arg.noCacheDefault,
     }
   }
 

--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -253,7 +253,7 @@ export class Plugin implements IPlugin {
   protected async _manifest(isWritingManifest = false): Promise<Manifest> {
     const ignoreManifest = Boolean(this.options.ignoreManifest)
     const errorOnManifestCreate = Boolean(this.options.errorOnManifestCreate)
-    const respectNoCacheDefault = isWritingManifest ?? Boolean(this.options.respectNoCacheDefault)
+    const respectNoCacheDefault = isWritingManifest || Boolean(this.options.respectNoCacheDefault)
 
     const readManifest = async (dotfile = false): Promise<Manifest | undefined> => {
       try {

--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -226,6 +226,11 @@ export type FlagProps = {
    * separate on spaces.
    */
   delimiter?: ',',
+  /**
+   * If true, the value returned by defaultHelp will not be cached in the oclif.manifest.json.
+   * This is helpful if the default value contains sensitive data that shouldn't be published to npm.
+   */
+  noCacheDefault?: boolean;
 }
 
 export type ArgProps = {
@@ -247,6 +252,11 @@ export type ArgProps = {
 
   options?: string[];
   ignoreStdin?: boolean;
+  /**
+   * If true, the value returned by defaultHelp will not be cached in the oclif.manifest.json.
+   * This is helpful if the default value contains sensitive data that shouldn't be published to npm.
+   */
+  noCacheDefault?: boolean;
 }
 
 export type BooleanFlagProps = FlagProps & {

--- a/src/interfaces/plugin.ts
+++ b/src/interfaces/plugin.ts
@@ -9,6 +9,7 @@ export interface PluginOptions {
   tag?: string;
   ignoreManifest?: boolean;
   errorOnManifestCreate?: boolean;
+  respectNoCacheDefault?: boolean;
   parent?: Plugin;
   children?: Plugin[];
 }

--- a/test/command/command.test.ts
+++ b/test/command/command.test.ts
@@ -152,6 +152,7 @@ describe('command', () => {
             allowNo: false,
             type: 'boolean',
             delimiter: undefined,
+            noCacheDefault: undefined,
           },
           flagb: {
             aliases: undefined,
@@ -174,6 +175,7 @@ describe('command', () => {
             default: 'a',
             options: ['a', 'b'],
             delimiter: undefined,
+            noCacheDefault: undefined,
           },
           flagc: {
             aliases: undefined,
@@ -199,6 +201,7 @@ describe('command', () => {
             required: false,
             summary: undefined,
             type: 'option',
+            noCacheDefault: undefined,
           },
 
         },
@@ -210,6 +213,7 @@ describe('command', () => {
             required: true,
             options: ['af', 'b'],
             default: 'a',
+            noCacheDefault: undefined,
           },
         },
       })


### PR DESCRIPTION
Add `noCacheDefault` flag and arg property. This will eventually replace the `isWritingManifest` functionality introduced by https://github.com/oclif/core/pull/675

Adding the property now allows for a smoother migration path for sf-plugins-core