### PR TITLE
feat: skip ts-node register for ESM plugins

### DIFF
--- a/src/config/ts-node.ts
+++ b/src/config/ts-node.ts
@@ -128,7 +128,7 @@ export function tsPath(root: string, orig: string | undefined, plugin?: Plugin):
   // - https://github.com/nodejs/node/pull/49407
   // - https://github.com/nodejs/node/issues/34049
   if (plugin?.moduleType === 'module') {
-    debug(`Skipping ts-node registration for ${root} because it's an ESM module but the root plugin is CommonJS`)
+    debug(`Skipping ts-node registration for ${root} because it's an ESM module`)
     if (plugin.type === 'link')
       memoizedWarn(`${plugin.name} is a linked ESM module and cannot be auto-transpiled. Existing compiled source will be used instead.`)
 

--- a/test/integration/esm-cjs.ts
+++ b/test/integration/esm-cjs.ts
@@ -365,34 +365,34 @@ type CleanUpOptions = {
     await test('Link ESM plugin to ESM root plugin', async () => {
       const plugin = PLUGINS.esm2
 
-      const linkedPlugin = await linkPlugin({executor: esmExecutor, plugin, script: 'run'})
+      await linkPlugin({executor: esmExecutor, plugin, script: 'run'})
       // test bin/run
-      // NOTE: this also tests that the compiled source is used when ts-node/esm loader is not specified
       await runCommand({
         executor: esmExecutor,
         plugin,
         script: 'run',
         expectStrings: [plugin.commandText, plugin.hookText],
       })
-      // test un-compiled changes with bin/run
-      await modifyCommand({executor: linkedPlugin, plugin, from: 'hello', to: 'howdy'})
-      await runCommand({
-        executor: esmExecutor,
-        plugin,
-        script: 'run',
-        expectStrings: ['howdy', plugin.hookText],
-        env: {NODE_OPTIONS: '--loader=ts-node/esm'},
-      })
 
-      // test un-compiled changes with bin/dev
-      await modifyCommand({executor: linkedPlugin, plugin, from: 'howdy', to: 'cheers'})
-      await runCommand({
-        executor: esmExecutor,
-        plugin,
-        script: 'dev',
-        expectStrings: ['cheers', plugin.hookText],
-        env: {NODE_OPTIONS: '--loader=ts-node/esm'},
-      })
+      // Skipping these because we decided to not support auto-transpiling ESM plugins at this time.
+      // // test un-compiled changes with bin/run
+      // await modifyCommand({executor: linkedPlugin, plugin, from: 'hello', to: 'howdy'})
+      // await runCommand({
+      //   executor: esmExecutor,
+      //   plugin,
+      //   script: 'run',
+      //   expectStrings: ['howdy', plugin.hookText],
+      //   env: {NODE_OPTIONS: '--loader=ts-node/esm'},
+      // })
+      // // test un-compiled changes with bin/dev
+      // await modifyCommand({executor: linkedPlugin, plugin, from: 'howdy', to: 'cheers'})
+      // await runCommand({
+      //   executor: esmExecutor,
+      //   plugin,
+      //   script: 'dev',
+      //   expectStrings: ['cheers', plugin.hookText],
+      //   env: {NODE_OPTIONS: '--loader=ts-node/esm'},
+      // })
 
       await cleanUp({executor: esmExecutor, plugin, script: 'run'})
     })


### PR DESCRIPTION
Skip ts-node registration for all ESM plugins, regardless of the root plugin type. The node ecosystem is not mature enough to support auto-transpiling ESM modules at this time.

See the following:
 - https://github.com/TypeStrong/ts-node/issues/1791#issuecomment-1149754228
 - https://github.com/nodejs/node/issues/49432
 - https://github.com/nodejs/node/pull/49407
 - https://github.com/nodejs/node/issues/34049