### PR TITLE
build(ejs): bump ejs v to 3.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean-stack": "^3.0.1",
     "cli-progress": "^3.12.0",
     "debug": "^4.3.4",
-    "ejs": "^3.1.8",
+    "ejs": "^3.1.9",
     "get-package-type": "^0.1.0",
     "globby": "^11.1.0",
     "hyperlinker": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1382,6 +1382,13 @@ ejs@^3.1.8:
   dependencies:
     jake "^10.8.5"
 
+ejs@^3.1.9:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.9.tgz#03c9e8777fe12686a9effcef22303ca3d8eeb361"
+  integrity sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==
+  dependencies:
+    jake "^10.8.5"
+
 electron-to-chromium@^1.3.846:
   version "1.3.848"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.848.tgz#94cc196e496f33c0d71cd98561448f10018584cc"


### PR DESCRIPTION
Bump ejs from v3.1.8 to 3.1.9 as BlackDuck scan reports security vulnerabilities for the v3.1.8 and recommends using 3.1.9
