### PR TITLE
feat: remove ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
     "strip-ansi": "^6.0.1",
     "supports-color": "^8.1.1",
     "supports-hyperlinks": "^2.2.0",
-    "ts-node": "^10.9.1",
-    "tslib": "^2.5.0",
     "widest-line": "^3.1.0",
     "wordwrap": "^1.0.0",
     "wrap-ansi": "^7.0.0"
@@ -72,6 +70,8 @@
     "shx": "^0.3.4",
     "sinon": "^11.1.2",
     "tsd": "^0.29.0",
+    "ts-node": "^10.9.1",
+    "tslib": "^2.5.0",
     "typescript": "^5"
   },
   "engines": {

--- a/src/config/ts-node.ts
+++ b/src/config/ts-node.ts
@@ -23,7 +23,11 @@ function loadTSConfig(root: string): TSConfig | undefined {
   } catch {
     try {
       typescript = require(join(root, 'node_modules', 'typescript'))
-    } catch {}
+    } catch {
+      debug(`Could not find typescript dependency. Skipping ts-node registration for ${root}.`)
+      memoizedWarn('Could not find typescript. Please ensure that typescript is a devDependency. Falling back to compiled source.')
+      return
+    }
   }
 
   if (existsSync(tsconfigPath) && typescript) {
@@ -49,7 +53,15 @@ function registerTSNode(root: string): TSConfig | undefined {
   debug('registering ts-node at', root)
   const tsNodePath = require.resolve('ts-node', {paths: [root, __dirname]})
   debug('ts-node path:', tsNodePath)
-  const tsNode: typeof TSNode = require(tsNodePath)
+  let tsNode: typeof TSNode
+
+  try {
+    tsNode = require(tsNodePath)
+  } catch {
+    debug(`Could not find ts-node at ${tsNodePath}. Skipping ts-node registration for ${root}.`)
+    memoizedWarn(`Could not find ts-node at ${tsNodePath}. Please ensure that ts-node is a devDependency. Falling back to compiled source.`)
+    return
+  }
 
   const typeRoots = [
     join(root, 'node_modules', '@types'),

--- a/test/integration/sf.e2e.ts
+++ b/test/integration/sf.e2e.ts
@@ -115,7 +115,7 @@ describe('Salesforce CLI (sf)', () => {
 
     expect(results.failures).to.be.empty
 
-    const unset = await executor.executeCommand('config unset disable-telemetry org-api-version --global')
+    const unset = await executor.executeCommand('config unset disable-telemetry org-api-version --global --json')
     const unsetParsed = parseJson(unset.stdout!)
     expect(unsetParsed.status).to.equal(0)
   })


### PR DESCRIPTION
Move `ts-node` to devDependency. This will require linked plugins to have `ts-node` as a devDependency

Fixes #735 