### PR TITLE
fix: show deprecation warning in help when using deprecated alias

### DIFF
--- a/src/help/index.ts
+++ b/src/help/index.ts
@@ -161,9 +161,15 @@ export class Help extends HelpBase {
     if (state) {
       this.log(
         state === 'deprecated'
-          ? `${formatCommandDeprecationWarning(toConfiguredId(name, this.config), command.deprecationOptions)}`
+          ? `${formatCommandDeprecationWarning(toConfiguredId(name, this.config), command.deprecationOptions)}\n`
           : `This command is in ${state}.\n`,
       )
+    }
+
+    if (command.deprecateAliases && command.aliases.includes(name)) {
+      const actualCmd = this.config.commands.find((c) => c.aliases.includes(name))
+      const opts = {...command.deprecationOptions, ...(actualCmd ? {to: actualCmd.id} : {})}
+      this.log(`${formatCommandDeprecationWarning(toConfiguredId(name, this.config), opts)}\n`)
     }
 
     const summary = this.summary(command)

--- a/test/help/fixtures/fixtures.ts
+++ b/test/help/fixtures/fixtures.ts
@@ -126,3 +126,20 @@ export const DbTopic: Topic = {
   name: 'db',
   description: 'This topic is for the db topic',
 }
+
+// deprecateAliases
+export class DeprecateAliases extends Command {
+  static id = 'foo:bar'
+
+  static aliases = ['foo:bar:alias']
+
+  static deprecateAliases = true
+
+  static flags = {}
+
+  static args = {}
+
+  async run(): Promise<void> {
+    'run'
+  }
+}

--- a/test/help/show-help.test.ts
+++ b/test/help/show-help.test.ts
@@ -52,25 +52,6 @@ const test = base
       for (const stub of Object.values(ctx.stubs)) stub.restore()
     },
   }))
-  .register('setupDeprecatedAliasesHelp', () => ({
-    async run(ctx: {help: TestHelp; stubs: {[k: string]: SinonStub}}) {
-      ctx.stubs = {
-        showRootHelp: stub(TestHelp.prototype, 'showRootHelp').resolves(),
-        showTopicHelp: stub(TestHelp.prototype, 'showTopicHelp').resolves(),
-        showCommandHelp: stub(TestHelp.prototype, 'showCommandHelp').resolves(),
-      }
-
-      // use devPlugins: true to bring in plugins-plugin with topic commands for testing
-      const config = await Config.load({devPlugins: true, root: resolve(__dirname, '..')})
-      const pluginPlugins = config.plugins.get('@oclif/plugin-plugins')!
-      const pluginsInstall = pluginPlugins.commands.find((c) => c.id === 'plugins:install')!
-      pluginPlugins.commands = [...pluginPlugins.commands, {...pluginsInstall, deprecateAliases: true}]
-      ctx.help = new TestHelp(config)
-    },
-    finally(ctx) {
-      for (const stub of Object.values(ctx.stubs)) stub.restore()
-    },
-  }))
   .register('makeTopicsWithoutCommand', () => ({
     async run(ctx: {help: TestHelp; makeTopicOnlyStub: SinonStub}) {
       // by returning no matching command for a subject, it becomes a topic only


### PR DESCRIPTION
Show standard deprecation warning in help when using a deprecated alias

@W-14208399@

Fixes https://github.com/oclif/core/issues/800