### PR TITLE
fix: only Command.Loadable in Help

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -378,15 +378,30 @@ export abstract class Command {
 }
 
 export namespace Command {
+  /**
+   * The Command class exported by a command file.
+   */
   export type Class = typeof Command & {
     id: string
     run(argv?: string[], config?: LoadOptions): Promise<any>
   }
 
+  /**
+   * A cached command that's had a `load` method attached to it.
+   *
+   * The `Plugin` class loads the commands from the manifest (if it exists) or requires and caches
+   * the commands directly from the commands directory inside the plugin. At this point the plugin
+   * is working with `Command.Cached`. It then appends a `load` method to each one. If the a command
+   * is executed then the `load` method is used to require the command class.
+   */
   export type Loadable = Cached & {
     load(): Promise<Command.Class>
   }
 
+  /**
+   * A cached version of the command. This is created by the cachedCommand utility and
+   * stored in the oclif.manifest.json.
+   */
   export type Cached = {
     [key: string]: unknown
     aliasPermutations?: string[]

--- a/src/command.ts
+++ b/src/command.ts
@@ -383,7 +383,7 @@ export namespace Command {
     run(argv?: string[], config?: LoadOptions): Promise<any>
   }
 
-  export interface Loadable extends Cached {
+  export type Loadable = Cached & {
     load(): Promise<Command.Class>
   }
 
@@ -392,6 +392,7 @@ export namespace Command {
     aliasPermutations?: string[]
     aliases: string[]
     args: {[name: string]: Arg.Cached}
+    deprecateAliases?: boolean
     deprecationOptions?: Deprecation
     description?: string
     examples?: Example[]

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -13,19 +13,23 @@ import {settings} from './settings'
  * @example For ESM dev.js
  * ```
  * #!/usr/bin/env ts-node
- * void (async () => {
+ * async function main() {
  *   const oclif = await import('@oclif/core')
  *   await oclif.execute({development: true, dir: import.meta.url})
- * })()
+ * }
+ *
+ * await main()
  * ```
  *
  * @example For ESM run.js
  * ```
  * #!/usr/bin/env node
- * void (async () => {
+ * async function main() {
  *   const oclif = await import('@oclif/core')
  *   await oclif.execute({dir: import.meta.url})
- * })()
+ * }
+ *
+ * await main()
  * ```
  *
  * @example For CJS dev.js

--- a/src/help/command.ts
+++ b/src/help/command.ts
@@ -22,7 +22,7 @@ if (process.env.ConEmuANSI === 'ON') {
 
 export class CommandHelp extends HelpFormatter {
   constructor(
-    public command: Command.Cached | Command.Class | Command.Loadable,
+    public command: Command.Loadable,
     public config: Interfaces.Config,
     public opts: Interfaces.HelpOptions,
   ) {

--- a/src/help/formatter.ts
+++ b/src/help/formatter.ts
@@ -15,7 +15,7 @@ export type HelpSection =
   | {body: [string, string | undefined][] | HelpSectionKeyValueTable | string | undefined; header: string}
   | undefined
 export type HelpSectionRenderer = (
-  data: {args: Command.Arg.Any[]; cmd: Command.Cached | Command.Class | Command.Loadable; flags: Command.Flag.Any[]},
+  data: {args: Command.Arg.Any[]; cmd: Command.Loadable; flags: Command.Flag.Any[]},
   header: string,
 ) => HelpSection | HelpSection[] | string | undefined
 

--- a/src/help/index.ts
+++ b/src/help/index.ts
@@ -38,7 +38,7 @@ export abstract class HelpBase extends HelpFormatter {
    * @param command
    * @param topics
    */
-  public abstract showCommandHelp(command: Command.Class, topics: Interfaces.Topic[]): Promise<void>
+  public abstract showCommandHelp(command: Command.Loadable, topics: Interfaces.Topic[]): Promise<void>
 
   /**
    * Show help, used in multi-command CLIs
@@ -68,11 +68,11 @@ export class Help extends HelpBase {
     })
   }
 
-  protected command(command: Command.Class): string {
+  protected command(command: Command.Loadable): string {
     return this.formatCommand(command)
   }
 
-  protected description(c: Command.Cached | Command.Class | Command.Loadable): string {
+  protected description(c: Command.Loadable): string {
     const description = this.render(c.description || '')
     if (c.summary) {
       return description
@@ -81,7 +81,7 @@ export class Help extends HelpBase {
     return description.split('\n').slice(1).join('\n')
   }
 
-  protected formatCommand(command: Command.Cached | Command.Class | Command.Loadable): string {
+  protected formatCommand(command: Command.Loadable): string {
     if (this.config.topicSeparator !== ':') {
       command.id = command.id.replaceAll(':', this.config.topicSeparator)
       command.aliases = command.aliases && command.aliases.map((a) => a.replaceAll(':', this.config.topicSeparator))
@@ -91,7 +91,7 @@ export class Help extends HelpBase {
     return help.generate()
   }
 
-  protected formatCommands(commands: Array<Command.Cached | Command.Class | Command.Loadable>): string {
+  protected formatCommands(commands: Array<Command.Loadable>): string {
     if (commands.length === 0) return ''
 
     const body = this.renderList(
@@ -145,7 +145,7 @@ export class Help extends HelpBase {
     return this.section('TOPICS', body)
   }
 
-  protected getCommandHelpClass(command: Command.Cached | Command.Class | Command.Loadable): CommandHelp {
+  protected getCommandHelpClass(command: Command.Loadable): CommandHelp {
     return new this.CommandHelpClass(command, this.config, this.opts)
   }
 
@@ -153,7 +153,7 @@ export class Help extends HelpBase {
     stdout.write(format.apply(this, args) + '\n')
   }
 
-  public async showCommandHelp(command: Command.Cached | Command.Class | Command.Loadable): Promise<void> {
+  public async showCommandHelp(command: Command.Loadable): Promise<void> {
     const name = command.id
     const depth = name.split(':').length
 
@@ -319,7 +319,7 @@ export class Help extends HelpBase {
     }
   }
 
-  protected summary(c: Command.Cached | Command.Class | Command.Loadable): string | undefined {
+  protected summary(c: Command.Loadable): string | undefined {
     if (c.summary) return this.render(c.summary.split('\n')[0])
 
     return c.description && this.render(c.description).split('\n')[0]

--- a/test/help/fixtures/fixtures.ts
+++ b/test/help/fixtures/fixtures.ts
@@ -143,3 +143,14 @@ export class DeprecateAliases extends Command {
     'run'
   }
 }
+
+export class LongDescription extends Command {
+  static description =
+    'This is a very long command description that should wrap after too many characters have been entered'
+
+  static id = 'hello:world'
+
+  async run(): Promise<void> {
+    'run'
+  }
+}

--- a/test/help/format-command.test.ts
+++ b/test/help/format-command.test.ts
@@ -1,55 +1,49 @@
-import {test as base, expect} from '@oclif/test'
+import {expect} from 'chai'
 
-import {Args, Command as Base, Flags as flags} from '../../src'
-import {TestHelp, commandHelp} from './help-test-utils'
+import {Args, Config, Flags as flags} from '../../src'
+import {TestHelp, makeCommandClass, makeLoadable} from './help-test-utils'
 
 const g: any = global
 g.oclif.columns = 80
 
-class Command extends Base {
-  async run() {
-    return null
-  }
-}
-
-const test = base
-  .loadConfig()
-  .add('help', (ctx) => new TestHelp(ctx.config as any))
-  .register('commandHelp', commandHelp)
-
 describe('formatCommand', () => {
-  test
-    .commandHelp(
-      class extends Command {
-        static {
-          this.id = 'apps:create'
+  let config: Config
+  let help: TestHelp
 
-          this.aliases = ['app:init', 'create']
+  before(async () => {
+    config = await Config.load(process.cwd())
+  })
 
-          this.description = `first line
+  beforeEach(() => {
+    help = new TestHelp(config)
+  })
 
-  multiline help`
+  it('should handle multi-line help output', async () => {
+    const cmd = await makeLoadable(
+      makeCommandClass({
+        id: 'apps:create',
+        aliases: ['app:init', 'create'],
+        description: `first line
 
-          this.enableJsonFlag = true
-
-          this.args = {
-            // eslint-disable-next-line camelcase
-            app_name: Args.string({description: 'app to use'}),
-          }
-
-          this.flags = {
-            app: flags.string({char: 'a', hidden: true}),
-            foo: flags.string({char: 'f', description: 'foobar'.repeat(18)}),
-            force: flags.boolean({description: 'force  it '.repeat(15)}),
-            ss: flags.boolean({description: 'newliney\n'.repeat(4)}),
-            remote: flags.string({char: 'r'}),
-            label: flags.string({char: 'l', helpLabel: '-l'}),
-          }
-        }
-      },
+multiline help`,
+        enableJsonFlag: true,
+        args: {
+          // eslint-disable-next-line camelcase
+          app_name: Args.string({description: 'app to use'}),
+        },
+        flags: {
+          app: flags.string({char: 'a', hidden: true}),
+          foo: flags.string({char: 'f', description: 'foobar'.repeat(18)}),
+          force: flags.boolean({description: 'force  it '.repeat(15)}),
+          ss: flags.boolean({description: 'newliney\n'.repeat(4)}),
+          remote: flags.string({char: 'r'}),
+          label: flags.string({char: 'l', helpLabel: '-l'}),
+        },
+      }),
     )
-    .it('handles multi-line help output', (ctx: any) =>
-      expect(ctx.commandHelp).to.equal(`USAGE
+
+    const output = help.formatCommand(cmd)
+    expect(output).to.equal(`USAGE
   $ oclif apps:create [APP_NAME] [--json] [-f <value>] [--force] [--ss]
     [-r <value>] [-l <value>]
 
@@ -79,39 +73,33 @@ DESCRIPTION
 
 ALIASES
   $ oclif app:init
-  $ oclif create`),
-    )
+  $ oclif create`)
+  })
 
   describe('arg and flag multiline handling', () => {
-    test
-      .commandHelp(
-        class extends Command {
-          static {
-            this.id = 'apps:create'
-
-            this.description = 'description of apps:create'
-
-            this.aliases = ['app:init', 'create']
-
-            this.enableJsonFlag = true
-
-            this.args = {
-              // eslint-disable-next-line camelcase
-              app_name: Args.string({description: 'app to use'.repeat(35)}),
-            }
-
-            this.flags = {
-              app: flags.string({char: 'a', hidden: true}),
-              foo: flags.string({char: 'f', description: 'foobar'.repeat(15)}),
-              force: flags.boolean({description: 'force  it '.repeat(15)}),
-              ss: flags.boolean({description: 'newliney\n'.repeat(4)}),
-              remote: flags.string({char: 'r'}),
-            }
-          }
-        },
+    it('should show args and flags side by side when their output do not exceed 4 lines ', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          aliases: ['app:init', 'create'],
+          description: 'description of apps:create',
+          enableJsonFlag: true,
+          args: {
+            // eslint-disable-next-line camelcase
+            app_name: Args.string({description: 'app to use'.repeat(35)}),
+          },
+          flags: {
+            app: flags.string({char: 'a', hidden: true}),
+            foo: flags.string({char: 'f', description: 'foobar'.repeat(15)}),
+            force: flags.boolean({description: 'force  it '.repeat(15)}),
+            ss: flags.boolean({description: 'newliney\n'.repeat(4)}),
+            remote: flags.string({char: 'r'}),
+          },
+        }),
       )
-      .it('show args and flags side by side when their output do not exceed 4 lines ', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif apps:create [APP_NAME] [--json] [-f <value>] [--force] [--ss]
     [-r <value>]
 
@@ -143,38 +131,32 @@ DESCRIPTION
 
 ALIASES
   $ oclif app:init
-  $ oclif create`),
+  $ oclif create`)
+    })
+
+    it('should show stacked args and flags when the lines exceed 4', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          description: 'description of apps:create',
+          aliases: ['app:init', 'create'],
+          enableJsonFlag: true,
+          args: {
+            // eslint-disable-next-line camelcase
+            app_name: Args.string({description: 'app to use'.repeat(35)}),
+          },
+          flags: {
+            app: flags.string({char: 'a', hidden: true}),
+            foo: flags.string({char: 'f', description: 'foobar'.repeat(20)}),
+            force: flags.boolean({description: 'force  it '.repeat(29)}),
+            ss: flags.boolean({description: 'newliney\n'.repeat(5)}),
+            remote: flags.string({char: 'r'}),
+          },
+        }),
       )
 
-    test
-      .commandHelp(
-        class extends Command {
-          static {
-            this.id = 'apps:create'
-
-            this.description = 'description of apps:create'
-
-            this.aliases = ['app:init', 'create']
-
-            this.enableJsonFlag = true
-
-            this.args = {
-              // eslint-disable-next-line camelcase
-              app_name: Args.string({description: 'app to use'.repeat(35)}),
-            }
-
-            this.flags = {
-              app: flags.string({char: 'a', hidden: true}),
-              foo: flags.string({char: 'f', description: 'foobar'.repeat(20)}),
-              force: flags.boolean({description: 'force  it '.repeat(29)}),
-              ss: flags.boolean({description: 'newliney\n'.repeat(5)}),
-              remote: flags.string({char: 'r'}),
-            }
-          }
-        },
-      )
-      .it('shows stacked args and flags when the lines exceed 4', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif apps:create [APP_NAME] [--json] [-f <value>] [--force] [--ss]
     [-r <value>]
 
@@ -214,72 +196,65 @@ DESCRIPTION
 
 ALIASES
   $ oclif app:init
-  $ oclif create`),
-      )
+  $ oclif create`)
+    })
   })
 
   describe('summary', () => {
-    test
-      .commandHelp(
-        class extends Command {
-          static id = 'test:summary'
-
-          static summary = 'one line summary'
-        },
-      )
-      .it('no description header if only a summary', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
-  $ oclif test:summary`),
+    it('should not show description header if only a summary', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'test:summary',
+          summary: 'one line summary',
+        }),
       )
 
-    test
-      .commandHelp(
-        class extends Command {
-          static description = 'description that is much longer than the summary'
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
+  $ oclif test:summary`)
+    })
 
-          static id = 'test:summary'
-
-          static summary = 'one line summary'
-        },
+    it('should output the summary at the top of the help and description', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'test:summary',
+          summary: 'one line summary',
+          description: 'description that is much longer than the summary',
+        }),
       )
-      .it('outputs the summary at the top of the help and description', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif test:summary
 
 DESCRIPTION
   one line summary
 
-  description that is much longer than the summary`),
-      )
+  description that is much longer than the summary`)
+    })
   })
 
   describe('description', () => {
-    test
-      .commandHelp(
-        class extends Command {
-          static {
-            this.id = 'apps:create'
-
-            this.description =
-              'description of apps:create\n\nthese values are after and will show up in the command description'
-
-            this.aliases = ['app:init', 'create']
-
-            this.enableJsonFlag = true
-
-            this.args = {
-              // eslint-disable-next-line camelcase
-              app_name: Args.string({description: 'app to use'}),
-            }
-
-            this.flags = {
-              force: flags.boolean({description: 'forces'}),
-            }
-          }
-        },
+    it('should output the command description with the values after a \\n newline character', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          description:
+            'description of apps:create\n\nthese values are after and will show up in the command description',
+          aliases: ['app:init', 'create'],
+          enableJsonFlag: true,
+          args: {
+            // eslint-disable-next-line camelcase
+            app_name: Args.string({description: 'app to use'}),
+          },
+          flags: {
+            force: flags.boolean({description: 'forces'}),
+          },
+        }),
       )
-      .it('outputs command description with values after a \\n newline character', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif apps:create [APP_NAME] [--json] [--force]
 
 ARGUMENTS
@@ -298,37 +273,37 @@ DESCRIPTION
 
 ALIASES
   $ oclif app:init
-  $ oclif create`),
+  $ oclif create`)
+    })
+
+    it('should render the template string from description', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          description: 'root part of the description\n\nThe <%= config.bin %> CLI has <%= command.id %>',
+        }),
       )
 
-    test
-      .commandHelp(
-        class extends Command {
-          static description = 'root part of the description\n\nThe <%= config.bin %> CLI has <%= command.id %>'
-
-          static id = 'apps:create'
-        },
-      )
-      .it('renders template string from description', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif apps:create
 
 DESCRIPTION
   root part of the description
 
-  The oclif CLI has apps:create`),
+  The oclif CLI has apps:create`)
+    })
+
+    it('should split on carriage return and new lines', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          description: 'root part of the description\r\n\nusing both carriage \n\nreturn and new line',
+        }),
       )
 
-    test
-      .commandHelp(
-        class extends Command {
-          static description = 'root part of the description\r\n\nusing both carriage \n\nreturn and new line'
-
-          static id = 'apps:create'
-        },
-      )
-      .it('splits on carriage return and new lines', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif apps:create
 
 DESCRIPTION
@@ -336,77 +311,74 @@ DESCRIPTION
 
   using both carriage
 
-  return and new line`),
-      )
+  return and new line`)
+    })
   })
 
   const myEnumValues = ['a', 'b', 'c']
   describe('flags', () => {
-    test
-      .commandHelp(
-        class extends Command {
-          static {
-            this.id = 'apps:create'
-
-            this.flags = {
-              myenum: flags.string({
-                description: 'the description',
-                options: myEnumValues,
-              }),
-            }
-          }
-        },
+    it('should output flag enum', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          flags: {
+            myenum: flags.string({
+              description: 'the description',
+              options: myEnumValues,
+            }),
+          },
+        }),
       )
-      .it('outputs flag enum', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif apps:create [--myenum a|b|c]
 
 FLAGS
   --myenum=<option>  the description
-                     <options: a|b|c>`),
-      )
+                     <options: a|b|c>`)
+    })
 
-    test
-      .commandHelp(
-        class extends Command {
-          static flags = {
+    it('should output flag enum with helpValue', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          flags: {
             myenum: flags.string({
               options: myEnumValues,
               helpValue: myEnumValues.join('|'),
             }),
-          }
-
-          static id = 'apps:create'
-        },
+          },
+        }),
       )
-      .it('outputs flag enum with helpValue', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif apps:create [--myenum a|b|c]
 
 FLAGS
-  --myenum=a|b|c`),
-      )
+  --myenum=a|b|c`)
+    })
 
-    test
-      .commandHelp(
-        class extends Command {
-          static args = {
+    it('should output with default flag options', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          args: {
             arg1: Args.string({default: '.'}),
             arg2: Args.string({default: '.', description: 'arg2 desc'}),
             arg3: Args.string({description: 'arg3 desc'}),
-          }
-
-          static flags = {
+          },
+          flags: {
             flag1: flags.string({default: '.'}),
             flag2: flags.string({default: '.', description: 'flag2 desc'}),
             flag3: flags.string({description: 'flag3 desc'}),
-          }
-
-          static id = 'apps:create'
-        },
+          },
+        }),
       )
-      .it('outputs with default flag options', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif apps:create [ARG1] [ARG2] [ARG3] [--flag1 <value>] [--flag2
     <value>] [--flag3 <value>]
 
@@ -418,42 +390,42 @@ ARGUMENTS
 FLAGS
   --flag1=<value>  [default: .]
   --flag2=<value>  [default: .] flag2 desc
-  --flag3=<value>  flag3 desc`),
-      )
+  --flag3=<value>  flag3 desc`)
+    })
 
-    test
-      .commandHelp(
-        class extends Command {
-          static flags = {
+    it('should output flags with no options', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          flags: {
             opt: flags.boolean({allowNo: true}),
-          }
-
-          static id = 'apps:create'
-        },
+          },
+        }),
       )
-      .it('outputs with with no options', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif apps:create [--opt]
 
 FLAGS
-  --[no-]opt`),
-      )
+  --[no-]opt`)
+    })
 
-    test
-      .commandHelp(
-        class extends Command {
-          static flags = {
+    it('should output flag summary and description', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          flags: {
             opt: flags.string({
               summary: 'one line summary',
               description: 'multiline\ndescription',
             }),
-          }
-
-          static id = 'apps:create'
-        },
+          },
+        }),
       )
-      .it('outputs flag summary and description', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif apps:create [--opt <value>]
 
 FLAGS
@@ -463,24 +435,24 @@ FLAG DESCRIPTIONS
   --opt=<value>  one line summary
 
     multiline
-    description`),
-      )
+    description`)
+    })
 
-    test
-      .commandHelp(
-        class extends Command {
-          static flags = {
+    it('should output flag summary and single line description', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          flags: {
             opt: flags.string({
               summary: 'one line summary',
               description: 'single line description',
             }),
-          }
-
-          static id = 'apps:create'
-        },
+          },
+        }),
       )
-      .it('outputs flag summary and single line description', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif apps:create [--opt <value>]
 
 FLAGS
@@ -489,24 +461,24 @@ FLAGS
 FLAG DESCRIPTIONS
   --opt=<value>  one line summary
 
-    single line description`),
-      )
+    single line description`)
+    })
 
-    test
-      .commandHelp(
-        class extends Command {
-          static flags = {
+    it('should output long flag summary and single line description', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          flags: {
             opt: flags.string({
               summary: 'one line summary'.repeat(15),
               description: 'single line description',
             }),
-          }
-
-          static id = 'apps:create'
-        },
+          },
+        }),
       )
-      .it('outputs long flag summary and single line description', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif apps:create [--opt <value>]
 
 FLAGS
@@ -523,232 +495,230 @@ FLAG DESCRIPTIONS
     line summaryone line summaryone line summaryone line summaryone line
     summaryone line summary
 
-    single line description`),
-      )
+    single line description`)
+    })
   })
 
   describe('args', () => {
-    test
-      .commandHelp(
-        class extends Command {
-          static args = {
+    it('should output with arg options', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          args: {
             arg1: Args.string({description: 'Show the options', options: ['option1', 'option2']}),
-          }
-
-          static id = 'apps:create'
-        },
+          },
+        }),
       )
-      .it('outputs with arg options', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif apps:create [ARG1]
 
 ARGUMENTS
-  ARG1  (option1|option2) Show the options`),
-      )
+  ARG1  (option1|option2) Show the options`)
+    })
   })
 
   describe('usage', () => {
-    test
-      .commandHelp(
-        class extends Command {
-          static id = 'apps:create'
-
-          static usage = '<%= config.bin %> <%= command.id %> usage'
-        },
-      )
-      .it('outputs usage with templates', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
-  $ oclif oclif apps:create usage`),
+    it('should output usage with templates', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          usage: '<%= config.bin %> <%= command.id %> usage',
+        }),
       )
 
-    test
-      .commandHelp(
-        class extends Command {
-          static id = 'apps:create'
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
+  $ oclif oclif apps:create usage`)
+    })
 
-          static usage = ['<%= config.bin %>', '<%= command.id %> usage']
-        },
+    it('should output usage arrays with templates', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          usage: ['<%= config.bin %>', '<%= command.id %> usage'],
+        }),
       )
-      .it('outputs usage arrays with templates', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif oclif
-  $ oclif apps:create usage`),
+  $ oclif apps:create usage`)
+    })
+
+    it('should output default usage when not specified', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+        }),
       )
 
-    test
-      .commandHelp(
-        class extends Command {
-          static id = 'apps:create'
-
-          static usage = undefined
-        },
-      )
-      .it('defaults usage when not specified', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
-  $ oclif apps:create`),
-      )
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
+  $ oclif apps:create`)
+    })
   })
 
   describe('examples', () => {
-    test
-      .commandHelp(
-        class extends Command {
-          static examples = ['it handles a list of examples', 'more example text']
-        },
+    it('should output multiple examples', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          examples: ['it handles a list of examples', 'more example text'],
+        }),
       )
-      .it('outputs multiple examples', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif
 
 EXAMPLES
   it handles a list of examples
 
-  more example text`),
+  more example text`)
+    })
+
+    it('should output a single example', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          examples: ['it handles a single example'],
+        }),
       )
 
-    test
-      .commandHelp(
-        class extends Command {
-          static examples = ['it handles a single example']
-        },
-      )
-      .it('outputs a single example', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif
 
 EXAMPLES
-  it handles a single example`),
+  it handles a single example`)
+    })
+
+    it('should output examples using templates', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          examples: ['the bin is <%= config.bin %>', 'the command id is <%= command.id %>'],
+          id: 'oclif:command',
+        }),
       )
 
-    test
-      .commandHelp(
-        class extends Command {
-          static examples = ['the bin is <%= config.bin %>', 'the command id is <%= command.id %>']
-
-          static id = 'oclif:command'
-        },
-      )
-      .it('outputs examples using templates', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif oclif:command
 
 EXAMPLES
   the bin is oclif
 
-  the command id is oclif:command`),
+  the command id is oclif:command`)
+    })
+
+    it('should format command', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          examples: ['<%= config.bin %> <%= command.id %> --help'],
+          id: 'oclif:command',
+        }),
       )
 
-    test
-      .commandHelp(
-        class extends Command {
-          static examples = ['<%= config.bin %> <%= command.id %> --help']
-
-          static id = 'oclif:command'
-        },
-      )
-      .it('formats if command', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif oclif:command
 
 EXAMPLES
-  $ oclif oclif:command --help`),
+  $ oclif oclif:command --help`)
+    })
+
+    it('should format command with description', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          examples: ['Prints out help.\n<%= config.bin %> <%= command.id %> --help'],
+          id: 'oclif:command',
+        }),
       )
 
-    test
-      .commandHelp(
-        class extends Command {
-          static examples = ['Prints out help.\n<%= config.bin %> <%= command.id %> --help']
-
-          static id = 'oclif:command'
-        },
-      )
-      .it('formats if command with description', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif oclif:command
 
 EXAMPLES
   Prints out help.
 
-    $ oclif oclif:command --help`),
-      )
+    $ oclif oclif:command --help`)
+    })
 
-    test
-      .commandHelp(
-        class extends Command {
-          static examples = [
+    it('should format command with description', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          examples: [
             'Prints out help.\n<%= config.bin %> <%= command.id %> --help\n<%= config.bin %> <%= command.id %> --help',
-          ]
-
-          static id = 'oclif:command'
-        },
+          ],
+          id: 'oclif:command',
+        }),
       )
-      .it('formats if multiple command with description', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif oclif:command
 
 EXAMPLES
   Prints out help.
 
     $ oclif oclif:command --help
-    $ oclif oclif:command --help`),
+    $ oclif oclif:command --help`)
+    })
+
+    it('should format example object', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          examples: [{description: 'Prints out help.', command: '<%= config.bin %> <%= command.id %> --help'}],
+          id: 'oclif:command',
+        }),
       )
 
-    test
-      .commandHelp(
-        class extends Command {
-          static examples = [{description: 'Prints out help.', command: '<%= config.bin %> <%= command.id %> --help'}]
-
-          static id = 'oclif:command'
-        },
-      )
-      .it('formats example object', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif oclif:command
 
 EXAMPLES
   Prints out help.
 
-    $ oclif oclif:command --help`),
+    $ oclif oclif:command --help`)
+    })
+
+    it('should format example object with long description', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          examples: [{description: 'force  it '.repeat(15), command: '<%= config.bin %> <%= command.id %> --help'}],
+          id: 'oclif:command',
+        }),
       )
 
-    test
-      .commandHelp(
-        class extends Command {
-          static examples = [
-            {description: 'force  it '.repeat(15), command: '<%= config.bin %> <%= command.id %> --help'},
-          ]
-
-          static id = 'oclif:command'
-        },
-      )
-      .it('formats example object with long description', (ctx: any) =>
-        expect(ctx.commandHelp).to.equal(`USAGE
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
   $ oclif oclif:command
 
 EXAMPLES
   force  it force  it force  it force  it force  it force  it force  it force
   it force  it force  it force  it force  it force  it force  it force  it
 
-    $ oclif oclif:command --help`),
-      )
+    $ oclif oclif:command --help`)
+    })
 
-    test
-      .commandHelp(
-        class extends Command {
-          static examples = [
+    it('should format example object with long command', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          examples: [
             {
               description: 'Prints out help.',
               command: '<%= config.bin %> <%= command.id %> ' + 'force  it '.repeat(15),
             },
-          ]
-
-          static id = 'oclif:command'
-        },
+          ],
+          id: 'oclif:command',
+        }),
       )
-      .it('formats example object with long command', (ctx: any) => {
-        const multilineSeparator =
-          ctx.config.platform === 'win32' ? (ctx.config.shell.includes('powershell') ? '`' : '^') : '\\'
-        expect(ctx.commandHelp).to.equal(`USAGE
+
+      const output = help.formatCommand(cmd)
+      const multilineSeparator = config.platform === 'win32' ? (config.shell.includes('powershell') ? '`' : '^') : '\\'
+      expect(output).to.equal(`USAGE
   $ oclif oclif:command
 
 EXAMPLES
@@ -757,6 +727,6 @@ EXAMPLES
     $ oclif oclif:command force  it force  it force  it force  it force  it ${multilineSeparator}
       force  it force  it force  it force  it force  it force  it force  it ${multilineSeparator}
       force  it force  it force  it`)
-      })
+    })
   })
 })

--- a/test/help/format-commands.test.ts
+++ b/test/help/format-commands.test.ts
@@ -1,71 +1,51 @@
-import {test as base, expect} from '@oclif/test'
+import {expect} from 'chai'
 
 import {Command} from '../../src/command'
 
-import stripAnsi = require('strip-ansi')
-
 const g: any = global
 g.oclif.columns = 80
+import {Config} from '../../src'
 import {Help} from '../../src/help'
-import {AppsCreate, AppsDestroy} from './fixtures/fixtures'
+import {AppsCreate, AppsDestroy, LongDescription} from './fixtures/fixtures'
+import {makeLoadable} from './help-test-utils'
 
 // extensions to expose method as public for testing
 class TestHelp extends Help {
-  public formatCommands(commands: Command.Class[]) {
+  public formatCommands(commands: Command.Loadable[]) {
     return super.formatCommands(commands)
   }
 }
 
-const formatCommands = (commands: Command.Class[]) => ({
-  run(ctx: {help: TestHelp; output: string}) {
-    const help = ctx.help.formatCommands(commands)
-    if (process.env.TEST_OUTPUT === '1') {
-      console.log(help)
-    }
-
-    ctx.output = stripAnsi(help)
-      .split('\n')
-      .map((s) => s.trimEnd())
-      .join('\n')
-  },
-})
-
-const test = base
-  .loadConfig()
-  .add('help', (ctx) => new TestHelp(ctx.config as any))
-  .register('formatCommands', formatCommands)
-
 describe('formatCommand', () => {
-  test
-    .formatCommands([])
-    .it('outputs an empty string when no commands are given', (ctx: any) => expect(ctx.output).to.equal(''))
+  let config: Config
+  let help: TestHelp
 
-  test
-    // @ts-ignore
-    .formatCommands([AppsDestroy, AppsCreate])
-    .it('shows a list of the provided commands', (ctx: any) =>
-      expect(ctx.output).to.equal(`COMMANDS
+  before(async () => {
+    config = await Config.load(process.cwd())
+  })
+
+  beforeEach(() => {
+    help = new TestHelp(config)
+  })
+
+  it('should output an empty string when no commands are given', async () => {
+    const output = help.formatCommands([])
+    expect(output).to.equal('')
+  })
+
+  it('should show a list of the provided commands', async () => {
+    const output = help.formatCommands([await makeLoadable(AppsDestroy), await makeLoadable(AppsCreate)])
+
+    expect(output).to.equal(`COMMANDS
   apps:destroy  Destroy an app
-  apps:create   Create an app`),
-    )
+  apps:create   Create an app`)
+  })
 
-  test
-    // @ts-ignore
-    .formatCommands([
-      class extends Command {
-        static description =
-          'This is a very long command description that should wrap after too many characters have been entered'
+  it('should handle wraps on long descriptions', async () => {
+    const output = help.formatCommands([await makeLoadable(LongDescription)])
 
-        static id = 'hello:world'
-
-        async run() {
-          'run'
-        }
-      },
-    ])
-    .it('handles wraps long descriptions', (ctx: any) =>
-      expect(ctx.output).to.equal(`COMMANDS
+    expect(output).to.equal(`COMMANDS
   hello:world  This is a very long command description that should wrap after
-               too many characters have been entered`),
-    )
+               too many characters have been entered`)
+  })
 })

--- a/test/help/show-customized-help.test.ts
+++ b/test/help/show-customized-help.test.ts
@@ -47,7 +47,7 @@ class TestHelp extends Help {
     return super.showTopicHelp(topic)
   }
 
-  summary(c: Command.Class): string {
+  summary(c: Command.Loadable): string {
     // This will essentially ignore the summary
     return this.wrap(c.description || '')
   }


### PR DESCRIPTION
- Update `execute` examples
- Only use `Command.Loadable` in `Help` code
- Un-fancy-ify `formatCommand` tests