### PR TITLE
fix: custom flags with union type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       - run: New-Item -Path D:\a -Name "e2e" -ItemType "directory"
       - run: New-Item -Path D:\a\e2e -Name "sf.e2e.ts" -ItemType "directory"
       - run: |
-          git clone https://github.com/salesforcecli/cli.git --branch mdonnalley/esm
+          git clone https://github.com/salesforcecli/cli.git
           cd cli
 
           $Json = Get-Content package.json | ConvertFrom-Json

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -145,30 +145,30 @@ export const help = (opts: Partial<BooleanFlag<boolean>> = {}): BooleanFlag<void
     },
   })
 
-type ElementType<T extends ReadonlyArray<unknown>> = T[number]
+type ReadonlyElementOf<T extends ReadonlyArray<unknown>> = T[number]
 
 export function option<T extends readonly string[], P extends CustomOptions>(
-  defaults: Partial<OptionFlag<ElementType<T>[], P>> & {
+  defaults: Partial<OptionFlag<ReadonlyElementOf<T>[], P>> & {
     multiple: true
     options: T
   } & (
       | {
-          default: OptionFlag<ElementType<T>[], P>['default'] | undefined
+          default: OptionFlag<ReadonlyElementOf<T>[], P>['default'] | undefined
         }
       | {required: true}
     ),
 ): FlagDefinition<(typeof defaults.options)[number], P, {multiple: true; requiredOrDefaulted: true}>
 
 export function option<T extends readonly string[], P extends CustomOptions>(
-  defaults: Partial<OptionFlag<ElementType<T>, P>> & {
+  defaults: Partial<OptionFlag<ReadonlyElementOf<T>, P>> & {
     multiple?: false | undefined
     options: T
-  } & ({default: OptionFlag<ElementType<T>, P>['default']} | {required: true}),
+  } & ({default: OptionFlag<ReadonlyElementOf<T>, P>['default']} | {required: true}),
 ): FlagDefinition<(typeof defaults.options)[number], P, {multiple: false; requiredOrDefaulted: true}>
 
 export function option<T extends readonly string[], P extends CustomOptions>(
-  defaults: Partial<OptionFlag<ElementType<T>, P>> & {
-    default?: OptionFlag<ElementType<T>, P>['default'] | undefined
+  defaults: Partial<OptionFlag<ReadonlyElementOf<T>, P>> & {
+    default?: OptionFlag<ReadonlyElementOf<T>, P>['default'] | undefined
     multiple?: false | undefined
     options: T
     required?: false | undefined
@@ -176,8 +176,8 @@ export function option<T extends readonly string[], P extends CustomOptions>(
 ): FlagDefinition<(typeof defaults.options)[number], P, {multiple: false; requiredOrDefaulted: false}>
 
 export function option<T extends readonly string[], P extends CustomOptions>(
-  defaults: Partial<OptionFlag<ElementType<T>[], P>> & {
-    default?: OptionFlag<ElementType<T>[], P>['default'] | undefined
+  defaults: Partial<OptionFlag<ReadonlyElementOf<T>[], P>> & {
+    default?: OptionFlag<ReadonlyElementOf<T>[], P>['default'] | undefined
     multiple: true
     options: T
     required?: false | undefined
@@ -197,7 +197,7 @@ export function option<T extends readonly string[], P extends CustomOptions>(
  * }
  */
 export function option<T extends readonly string[], P extends CustomOptions>(
-  defaults: Partial<OptionFlag<ElementType<T>, P>> & {options: T},
+  defaults: Partial<OptionFlag<ReadonlyElementOf<T>, P>> & {options: T},
 ): FlagDefinition<(typeof defaults.options)[number], P, {multiple: boolean; requiredOrDefaulted: boolean}> {
   return (options: any = {}) => ({
     parse: async (input, _ctx, _opts) => input,

--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -218,11 +218,13 @@ export type OptionFlagProps = FlagProps & {
 
 export type FlagParserContext = Command & {token: FlagToken}
 
+type NonNullableElementOf<T> = [NonNullable<T>] extends [Array<infer U>] ? U : T
+
 export type FlagParser<T, I extends string | boolean, P = CustomOptions> = (
   input: I,
   context: FlagParserContext,
   opts: P & OptionFlag<T, P>,
-) => T extends Array<infer U> ? Promise<U | undefined> : Promise<T | undefined>
+) => Promise<NonNullableElementOf<T> | undefined>
 
 export type ArgParserContext = Command & {token: ArgToken}
 

--- a/src/interfaces/pjson.ts
+++ b/src/interfaces/pjson.ts
@@ -34,6 +34,11 @@ export namespace PJSON {
         identifier?: string
         sign?: string
       }
+      windows?: {
+        homepage?: string
+        keypath?: string
+        name?: string
+      }
       plugins?: string[]
       repositoryPrefix?: string
       schema?: number

--- a/src/interfaces/pjson.ts
+++ b/src/interfaces/pjson.ts
@@ -64,6 +64,7 @@ export namespace PJSON {
   export interface S3 {
     acl?: string
     bucket?: string
+    folder?: string
     gz?: boolean
     host?: string
     templates: {

--- a/test/integration/sf.e2e.ts
+++ b/test/integration/sf.e2e.ts
@@ -19,7 +19,6 @@ describe('Salesforce CLI (sf)', () => {
     process.env.SFDX_TELEMETRY_DISABLE_ACKNOWLEDGEMENT = 'true'
     executor = await setup(__filename, {
       repo: 'https://github.com/salesforcecli/cli',
-      branch: 'mdonnalley/esm',
     })
   })
 

--- a/test/interfaces/flags.test-types.ts
+++ b/test/interfaces/flags.test-types.ts
@@ -337,6 +337,19 @@ class MyCommand extends BaseCommand {
       // TODO: THIS IS A BUG. It should enforce a single value instead of allowing a single value or an array
       default: ['foo'],
     }),
+
+    'custom-union#defs:parse': Flags.custom<'a' | 'b' | 'c'>({
+      async parse(input, _ctx, _opts) {
+        return input as 'a' | 'b' | 'c'
+      },
+    })(),
+
+    'custom-union#defs:parse,multiple': Flags.custom<'a' | 'b' | 'c'>({
+      async parse(input, _ctx, _opts) {
+        return input as 'a' | 'b' | 'c'
+      },
+      multiple: true,
+    })(),
   }
 
   public flags!: MyFlags
@@ -509,6 +522,9 @@ class MyCommand extends BaseCommand {
 
     // TODO: Known issue with `default` not enforcing the correct type whenever multiple is defaulted to true but then overridden to false
     // expectType<string>(this.flags['custom#defs:multiple=true;opts:multiple=false,default'])
+
+    expectType<'a' | 'b' | 'c' | undefined>(this.flags['custom-union#defs:parse'])
+    expectType<Array<'a' | 'b' | 'c'> | undefined>(this.flags['custom-union#defs:parse,multiple'])
 
     return result.flags
   }


### PR DESCRIPTION
Fixes issue with custom flags with union type unnecessarily enforcing `multiple: true`

Fixes #812 

@W-14261473@