### PR TITLE
fix: avoid fs.access for checking for file existence

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oclif/core",
   "description": "base library for oclif CLIs",
-  "version": "3.0.4",
+  "version": "3.0.5-dev.0",
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/core/issues",
   "dependencies": {

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -1552,11 +1552,9 @@ See more help with --help`)
 
   describe('fs flags', () => {
     const sandbox = createSandbox()
-    let accessStub: SinonStub
     let statStub: SinonStub
 
     beforeEach(() => {
-      accessStub = sandbox.stub(fs.promises, 'access')
       statStub = sandbox.stub(fs.promises, 'stat')
     })
 
@@ -1570,18 +1568,15 @@ See more help with --help`)
         const out = await parse([`--dir=${testDir}`], {
           flags: {dir: Flags.directory({exists: false})},
         })
-        expect(accessStub.callCount).to.equal(0)
         expect(out.flags).to.deep.include({dir: testDir})
       })
       it('passes if dir !exists but exists not defined', async () => {
         const out = await parse([`--dir=${testDir}`], {
           flags: {dir: Flags.directory()},
         })
-        expect(accessStub.callCount).to.equal(0)
         expect(out.flags).to.deep.include({dir: testDir})
       })
       it('passes when dir exists', async () => {
-        accessStub.resolves()
         statStub.returns({isDirectory: () => true})
         const out = await parse([`--dir=${testDir}`], {
           flags: {dir: Flags.directory({exists: true})},
@@ -1589,7 +1584,7 @@ See more help with --help`)
         expect(out.flags).to.deep.include({dir: testDir})
       })
       it("fails when dir doesn't exist", async () => {
-        accessStub.throws()
+        statStub.throws()
         try {
           const out = await parse([`--dir=${testDir}`], {
             flags: {dir: Flags.directory({exists: true})},
@@ -1601,7 +1596,6 @@ See more help with --help`)
         }
       })
       it('fails when dir exists but is not a dir', async () => {
-        accessStub.resolves()
         statStub.returns({isDirectory: () => false})
         try {
           const out = await parse([`--dir=${testDir}`], {
@@ -1616,7 +1610,6 @@ See more help with --help`)
       describe('custom parse functions', () => {
         const customParseException = 'NOT_OK'
         it('accepts custom parse that passes', async () => {
-          accessStub.resolves()
           statStub.returns({isDirectory: () => true})
           const out = await parse([`--dir=${testDir}`], {
             flags: {
@@ -1630,7 +1623,6 @@ See more help with --help`)
         })
 
         it('accepts custom parse that fails', async () => {
-          accessStub.resolves()
           statStub.returns({isDirectory: () => true})
           try {
             const out = await parse([`--dir=${testDir}`], {
@@ -1657,17 +1649,14 @@ See more help with --help`)
           flags: {file: Flags.file({exists: false})},
         })
         expect(out.flags).to.deep.include({file: testFile})
-        expect(accessStub.callCount).to.equal(0)
       })
       it("passes if file doesn't exist but not exists not defined", async () => {
         const out = await parse([`--file=${testFile}`], {
           flags: {file: Flags.file()},
         })
         expect(out.flags).to.deep.include({file: testFile})
-        expect(accessStub.callCount).to.equal(0)
       })
       it('passes when file exists', async () => {
-        accessStub.resolves()
         statStub.returns({isFile: () => true})
         const out = await parse([`--file=${testFile}`], {
           flags: {file: Flags.file({exists: true})},
@@ -1675,7 +1664,7 @@ See more help with --help`)
         expect(out.flags).to.deep.include({file: testFile})
       })
       it("fails when dir doesn't exist", async () => {
-        accessStub.throws()
+        statStub.throws()
         try {
           const out = await parse([`--file=${testFile}`], {
             flags: {file: Flags.file({exists: true})},
@@ -1687,7 +1676,6 @@ See more help with --help`)
         }
       })
       it('fails when file exists but is not a file', async () => {
-        accessStub.resolves()
         statStub.returns({isFile: () => false})
         try {
           const out = await parse([`--file=${testFile}`], {
@@ -1702,7 +1690,6 @@ See more help with --help`)
       describe('custom parse functions', () => {
         const customParseException = 'NOT_OK'
         it('accepts custom parse that passes', async () => {
-          accessStub.resolves()
           statStub.returns({isFile: () => true})
           const out = await parse([`--dir=${testFile}`], {
             flags: {
@@ -1716,7 +1703,6 @@ See more help with --help`)
         })
 
         it('accepts custom parse that fails', async () => {
-          accessStub.resolves()
           statStub.returns({isFile: () => true})
           try {
             const out = await parse([`--dir=${testFile}`], {

--- a/test/util/fs.test.ts
+++ b/test/util/fs.test.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
 
-import {readJson} from '../../src/util/fs'
+import {readJson, safeReadJson} from '../../src/util/fs'
 
 describe('readJson', () => {
   it('should return parsed JSON', async () => {
@@ -16,5 +16,17 @@ describe('readJson', () => {
       const err = error as Error
       expect(err.message).to.include('ENOENT: no such file or directory')
     }
+  })
+})
+
+describe('safeReadJson', () => {
+  it('should return parsed JSON', async () => {
+    const json = await safeReadJson<{name: string}>('package.json')
+    expect(json?.name).to.equal('@oclif/core')
+  })
+
+  it('should return undefined if the file does not exist', async () => {
+    const json = await safeReadJson('does-not-exist.json')
+    expect(json).to.be.undefined
   })
 })


### PR DESCRIPTION
No longer use `fs.access` to check for file existence, which is not recommended,

>Using fsPromises.access() to check for the accessibility of a file before calling fsPromises.open() is not recommended. Doing so introduces a race condition, since other processes may change the file's state between the two calls. Instead, user code should open/read/write the file directly and handle the error raised if the file is not accessible. 

Source: https://nodejs.org/api/fs.html#fspromisesaccesspath-mode

Fixes #815

@W-14266572@