### PR TITLE
fix: warn about ts-node and node 20

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
     "perfectionist/sort-object-types": "off",
     "perfectionist/sort-union-types": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-namespace": "off"
+    "@typescript-eslint/no-namespace": "off",
+    "valid-jsdoc": "off"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-@oclif/core
-===========
+# @oclif/core
 
 base library for oclif CLIs
 
@@ -7,9 +6,7 @@ base library for oclif CLIs
 [![Downloads/week](https://img.shields.io/npm/dw/@oclif/core.svg)](https://npmjs.org/package/@oclif/core)
 [![License](https://img.shields.io/npm/l/@oclif/core.svg)](https://github.com/oclif/core/blob/main/package.json)
 
-
-Migrating
-=====
+# Migrating
 
 See the [v3 migration guide](./guides/V3_MIGRATION.md) for an overview of breaking changes that occurred between v2 and v3.
 
@@ -17,19 +14,18 @@ See the [v2 migration guide](./guides/V2_MIGRATION.md) for an overview of breaki
 
 Migrating from `@oclif/config` and `@oclif/command`? See the [v1 migration guide](./guides/PRE_CORE_MIGRATION.md).
 
-CLI UX
-=====
+# CLI UX
 
 The [ux README](./src/cli-ux/README.md) contains detailed usage examples of using the `ux` export.
 
-Usage
-=====
+# Usage
 
 We strongly encourage you generate an oclif CLI using the [oclif cli](https://github.com/oclif/oclif). The generator will generate an npm package with `@oclif/core` as a dependency.
 
 You can, however, use `@oclif/core` in a standalone script like this:
+
 ```typescript
-#!/usr/bin/env ts-node
+#!/usr/bin/env -S node --loader ts-node/esm --no-warnings=ExperimentalWarning
 
 import * as fs from 'fs'
 import {Command, Flags, flush, handle} from '@oclif/core'
@@ -54,11 +50,14 @@ class LS extends Command {
   }
 }
 
-LS.run().then(async () => {
-  await flush()
-}, async (err) => {
-  await handle(err)
-})
+LS.run().then(
+  async () => {
+    await flush()
+  },
+  async (err) => {
+    await handle(err)
+  },
+)
 ```
 
 Then run it like this:

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -34,7 +34,7 @@ import {settings} from './settings'
  *
  * @example For CJS dev.js
  * ```
- * #!/usr/bin/env -S node --loader ts-node/esm --no-warnings=ExperimentalWarning
+ * #!/usr/bin/env ts-node
  * void (async () => {
  *   const oclif = await import('@oclif/core')
  *   await oclif.execute({development: true, dir: __dirname})

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -12,7 +12,7 @@ import {settings} from './settings'
  *
  * @example For ESM dev.js
  * ```
- * #!/usr/bin/env ts-node
+ * #!/usr/bin/env -S node --loader ts-node/esm --no-warnings=ExperimentalWarning
  * async function main() {
  *   const oclif = await import('@oclif/core')
  *   await oclif.execute({development: true, dir: import.meta.url})
@@ -34,7 +34,7 @@ import {settings} from './settings'
  *
  * @example For CJS dev.js
  * ```
- * #!/usr/bin/env ts-node
+ * #!/usr/bin/env -S node --loader ts-node/esm --no-warnings=ExperimentalWarning
  * void (async () => {
  *   const oclif = await import('@oclif/core')
  *   await oclif.execute({development: true, dir: __dirname})

--- a/test/integration/plugins.e2e.ts
+++ b/test/integration/plugins.e2e.ts
@@ -9,7 +9,7 @@ describe('oclif plugins', () => {
   let executor: Executor
   before(async () => {
     executor = await setup(__filename, {
-      repo: 'https://github.com/oclif/hello-world',
+      repo: 'https://github.com/oclif/hello-world-esm',
       plugins: [
         '@oclif/plugin-autocomplete',
         '@oclif/plugin-commands',
@@ -31,13 +31,13 @@ describe('oclif plugins', () => {
       })
 
       it('should show description', () => {
-        expect(help.stdout).to.include('oclif example Hello World CLI')
+        expect(help.stdout).to.include('oclif example Hello World CLI (ESM)')
       })
       it('should show version', () => {
-        expect(help.stdout).to.include('VERSION\n  oclif-hello-world/0.0.0')
+        expect(help.stdout).to.include('VERSION\n  oclif-hello-world-esm')
       })
       it('should show usage', () => {
-        expect(help.stdout).to.include('USAGE\n  $ oclif-hello-world [COMMAND]')
+        expect(help.stdout).to.include('USAGE\n  $ oclif-hello-world-esm [COMMAND]')
       })
       it('should show topics', () => {
         expect(help.stdout).to.include('TOPICS\n  plugins')
@@ -58,13 +58,13 @@ describe('oclif plugins', () => {
         expect(help.stdout).to.include('List installed plugins.')
       })
       it('should show usage', () => {
-        expect(help.stdout).to.include('USAGE\n  $ oclif-hello-world plugins [--json] [--core]')
+        expect(help.stdout).to.include('USAGE\n  $ oclif-hello-world-esm plugins [--json] [--core]')
       })
       it('should show description', () => {
         expect(help.stdout).to.include('DESCRIPTION\n  List installed plugins.')
       })
       it('should show examples', () => {
-        expect(help.stdout).to.include('EXAMPLES\n  $ oclif-hello-world plugins')
+        expect(help.stdout).to.include('EXAMPLES\n  $ oclif-hello-world-esm plugins')
       })
       it('should show commands', () => {
         const regex =
@@ -83,7 +83,7 @@ describe('oclif plugins', () => {
         expect(help.stdout).to.include('Installs a plugin into the CLI.')
       })
       it('should show usage', () => {
-        expect(help.stdout).to.include('USAGE\n  $ oclif-hello-world plugins:install PLUGIN...')
+        expect(help.stdout).to.include('USAGE\n  $ oclif-hello-world-esm plugins:install PLUGIN...')
       })
       it('should show arguments', () => {
         expect(help.stdout).to.include('ARGUMENTS\n  PLUGIN  Plugin to install.')
@@ -98,13 +98,13 @@ describe('oclif plugins', () => {
         expect(help.stdout).to.include('DESCRIPTION\n  Installs a plugin into the CLI.')
       })
       it('should show aliases', () => {
-        expect(help.stdout).to.include('ALIASES\n  $ oclif-hello-world plugins:add')
+        expect(help.stdout).to.include('ALIASES\n  $ oclif-hello-world-esm plugins:add')
       })
       it('should show examples', () => {
         expect(help.stdout).to.include('EXAMPLES\n')
-        expect(help.stdout).to.include('$ oclif-hello-world plugins:install myplugin')
-        expect(help.stdout).to.include('$ oclif-hello-world plugins:install https://github.com/someuser/someplugin')
-        expect(help.stdout).to.include('$ oclif-hello-world plugins:install someuser/someplugin')
+        expect(help.stdout).to.include('$ oclif-hello-world-esm plugins:install myplugin')
+        expect(help.stdout).to.include('$ oclif-hello-world-esm plugins:install https://github.com/someuser/someplugin')
+        expect(help.stdout).to.include('$ oclif-hello-world-esm plugins:install someuser/someplugin')
       })
     })
   })
@@ -261,7 +261,7 @@ describe('oclif plugins', () => {
       version = await executor.executeCommand('version')
     })
 
-    it('should show version', () => expect(version.stdout).to.include('oclif-hello-world/0.0.0'))
+    it('should show version', () => expect(version.stdout).to.include('oclif-hello-world-esm'))
     it('should show platform', () => expect(version.stdout).to.include(process.platform))
     it('should show arch', () => expect(version.stdout).to.include(arch()))
     it('should show node version', () => expect(version.stdout).to.include(process.version))


### PR DESCRIPTION
- Warn when `ts-node` is being used to execute `bin/dev.js` and node is >= 20
- Fall back to compiled source when `ts-node` cannot be used

Fixes https://github.com/oclif/core/issues/817

@W-14270164@