### PR TITLE
fix: add types for warn-if-update-available

### DIFF
--- a/src/interfaces/pjson.ts
+++ b/src/interfaces/pjson.ts
@@ -99,6 +99,12 @@ export namespace PJSON {
       nsisCustomization?: string
       schema?: number
       scope?: string
+      'warn-if-update-available'?: {
+        authorization: string
+        message: string
+        registry: string
+        timeoutInDays: number
+      }
     }
   }
 


### PR DESCRIPTION
So we can remove this `any`: https://github.com/oclif/plugin-warn-if-update-available/blob/main/src/hooks/init/check-update.ts#L16