### PR TITLE
Wr/spinner eats logs

### DIFF
--- a/src/cli-ux/action/spinner.ts
+++ b/src/cli-ux/action/spinner.ts
@@ -38,7 +38,10 @@ export default class SpinnerAction extends ActionBase {
   }
 
   private _lines(s: string): number {
-    return (stripAnsi(s).split('\n') as any[]).map((l) => Math.ceil(l.length / errtermwidth)).reduce((c, i) => c + i, 0)
+    return stripAnsi(s)
+      .split('\n')
+      .map((l) => Math.ceil(l.length / errtermwidth))
+      .reduce((c, i) => c + i, 0)
   }
 
   protected _pause(icon?: string): void {


### PR DESCRIPTION
fixes: https://github.com/oclif/core/issues/799

using the example in the issue, the output is now correct

```bash
 ➜  ./bin/dev demo
hello world 1
hello world 2
hello world 3
spinner... done
```