### PR TITLE
fix: handle ModuleLoadError from hooks

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -528,7 +528,17 @@ export class Config implements IConfig {
         } catch (error: any) {
           final.failures.push({error: error as Error, plugin: p})
           debug(error)
-          if (!captureErrors && error.oclif?.exit !== undefined) throw error
+          // Do not throw the error if
+          // captureErrors is set to true
+          // error.oclif.exit is undefined or 0
+          // error.code is MODULE_NOT_FOUND
+          if (
+            !captureErrors &&
+            error.oclif?.exit !== undefined &&
+            error.oclif?.exit !== 0 &&
+            error.code !== 'MODULE_NOT_FOUND'
+          )
+            throw error
         }
 
         marker?.addDetails({

--- a/src/config/plugin-loader.ts
+++ b/src/config/plugin-loader.ts
@@ -94,7 +94,7 @@ export default class PluginLoader {
   private async loadPlugins(
     root: string,
     type: string,
-    plugins: ({name?: string; root?: string; tag?: string} | string)[],
+    plugins: ({name?: string; root?: string; tag?: string; url?: string} | string)[],
     parent?: Plugin.Plugin,
   ): Promise<void> {
     if (!plugins || plugins.length === 0) return
@@ -112,6 +112,7 @@ export default class PluginLoader {
           if (typeof plugin !== 'string') {
             opts.tag = plugin.tag || opts.tag
             opts.root = plugin.root || opts.root
+            opts.url = plugin.url
           }
 
           if (parent) {

--- a/src/interfaces/plugin.ts
+++ b/src/interfaces/plugin.ts
@@ -14,6 +14,7 @@ export interface PluginOptions {
   root: string
   tag?: string
   type?: string
+  url?: string
 }
 
 export interface Options extends PluginOptions {
@@ -56,6 +57,7 @@ export interface Plugin {
    * name from package.json
    */
   name: string
+  readonly options: Options
   /**
    * full package.json
    *

--- a/test/config/config.flexible.test.ts
+++ b/test/config/config.flexible.test.ts
@@ -104,6 +104,7 @@ describe('Config with flexible taxonomy', () => {
       moduleType: 'commonjs',
       hasManifest: false,
       isRoot: false,
+      options: {root: ''},
     }
 
     const pluginB: IPlugin = {
@@ -125,6 +126,7 @@ describe('Config with flexible taxonomy', () => {
       moduleType: 'commonjs',
       hasManifest: false,
       isRoot: false,
+      options: {root: ''},
     }
     const plugins = new Map().set(pluginA.name, pluginA).set(pluginB.name, pluginB)
 

--- a/test/config/config.test.ts
+++ b/test/config/config.test.ts
@@ -293,6 +293,7 @@ describe('Config', () => {
         moduleType: 'commonjs',
         hasManifest: false,
         isRoot: false,
+        options: {root: ''},
       }
 
       const pluginB: IPlugin = {
@@ -314,6 +315,7 @@ describe('Config', () => {
         moduleType: 'commonjs',
         hasManifest: false,
         isRoot: false,
+        options: {root: ''},
       }
       const plugins = new Map().set(pluginA.name, pluginA).set(pluginB.name, pluginB)
       let test = fancy


### PR DESCRIPTION
- Never allow `MODULE_NOT_FOUND` error from hook to exit the process
- Allow user plugins from github urls to be auto-transpiled in production (CJS only)

QA
(from `salesforcecli/cli` repo)
- yarn link `@oclif/core`
- `bin/run.js plugins install https://github.com/oclif/plugin-test-esm-1.git`
- `bin/run.js plugins`
- `bin/run.js plugins install https://github.com/oclif/plugin-test-cjs-1.git`
- `bin/run.js plugins`

You should see no errors.
You should also see the hook text being output by the init hook from `@oclif/plugin-test-cjs-1`
You should **not** see the hook text being output by the init hook from `@oclif/plugin-test-esm-1` since we can't auto-transpile ESM plugins in production. This will be fixed by this [commit](https://github.com/oclif/plugin-plugins/pull/683/commits/88e9d021ad34128bc97bf8b6881739543aca99c7) in plugin-plugins

Fixes #835 

@W-14317382@