### PR TITLE
fix: clear commands belonging to legacy plugins before reloading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oclif/core",
   "description": "base library for oclif CLIs",
-  "version": "3.3.2",
+  "version": "3.3.3-dev.0",
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/core/issues",
   "dependencies": {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -756,6 +756,17 @@ export class Config implements IConfig {
   private insertLegacyPlugins(plugins: IPlugin[]) {
     for (const plugin of plugins) {
       this.plugins.set(plugin.name, plugin)
+
+      // Delete all commands from the legacy plugin so that we can re-add them.
+      // This is necessary because this.determinePriority will pick the initial
+      // command that was added, which won't have been converted by PluginLegacy yet.
+      for (const cmd of plugin.commands ?? []) {
+        this._commands.delete(cmd.id)
+        for (const alias of [...(cmd.aliases ?? []), ...(cmd.hiddenAliases ?? [])]) {
+          this._commands.delete(alias)
+        }
+      }
+
       this.loadCommands(plugin)
     }
   }


### PR DESCRIPTION
Clear out all commands (and aliases) belonging to legacy plugins before reloading them. Doing this ensure that the `determinePriority` won't keep the initial command that was loaded.

@W-14306614@