### PR TITLE
feat: run tsPath on hooks

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -511,7 +511,7 @@ export class Config implements IConfig {
         const marker = Performance.mark(OCLIF_MARKER_OWNER, `config.runHook#${p.name}(${hook})`)
         try {
           /* eslint-disable no-await-in-loop */
-          const {filePath, isESM, module} = await loadWithData(p, join(p.root, hook))
+          const {filePath, isESM, module} = await loadWithData(p, hook)
           debug('start', isESM ? '(import)' : '(require)', filePath)
 
           const result = timeout

--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -13,7 +13,7 @@ import {OCLIF_MARKER_OWNER, Performance} from '../performance'
 import {cacheCommand} from '../util/cache-command'
 import {findRoot} from '../util/find-root'
 import {readJson, requireJson} from '../util/fs'
-import {compact, isProd, mapValues} from '../util/util'
+import {castArray, compact, isProd, mapValues} from '../util/util'
 import {tsPath} from './ts-node'
 import {Debug, getCommandIdPermutations} from './util'
 
@@ -192,7 +192,7 @@ export class Plugin implements IPlugin {
       this.pjson.oclif = this.pjson['cli-engine'] || {}
     }
 
-    this.hooks = mapValues(this.pjson.oclif.hooks || {}, (i) => (Array.isArray(i) ? i : [i]))
+    this.hooks = mapValues(this.pjson.oclif.hooks ?? {}, (i) => castArray(i).map((i) => tsPath(this.root, i, this)))
 
     this.manifest = await this._manifest()
     this.commands = Object.entries(this.manifest.commands)


### PR DESCRIPTION
Run `tsPath` on all hook file paths to ensure that the correct path is used at run time in development