### PR TITLE
fix: support jsonc tsconfig

### DIFF
--- a/src/config/ts-node.ts
+++ b/src/config/ts-node.ts
@@ -15,7 +15,7 @@ export const TS_CONFIGS: Record<string, TSConfig> = {}
 const REGISTERED = new Set<string>()
 
 function isErrno(error: any): error is NodeJS.ErrnoException {
-  return 'code' in error
+  return 'code' in error && error.code === 'ENOENT'
 }
 
 async function loadTSConfig(root: string): Promise<TSConfig | undefined> {

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -60,24 +60,21 @@ export function readJsonSync<T = unknown>(path: string, parse = true): T | strin
   return parse ? (JSON.parse(contents) as T) : contents
 }
 
-/**
- * Read a JSON file, returning undefined if the file does not exist.
- */
 export async function safeReadJson<T>(path: string): Promise<T | undefined> {
   try {
     return await readJson<T>(path)
   } catch {}
 }
 
-/**
- * Read a file, returning undefined if the file does not exist.
- */
-export async function safeReadFile(path: string): Promise<string | undefined> {
-  try {
-    return await readFile(path, 'utf8')
-  } catch {}
-}
-
 export function existsSync(path: string): boolean {
   return fsExistsSync(path)
+}
+
+export async function readTSConfig(path: string) {
+  const {parse} = await import('tsconfck')
+  const result = await parse(path)
+  const tsNodeOpts = Object.fromEntries(
+    (result.extended ?? []).flatMap((e) => Object.entries(e.tsconfig['ts-node'] ?? {})).reverse(),
+  )
+  return {...result.tsconfig, 'ts-node': tsNodeOpts}
 }

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -60,9 +60,21 @@ export function readJsonSync<T = unknown>(path: string, parse = true): T | strin
   return parse ? (JSON.parse(contents) as T) : contents
 }
 
+/**
+ * Read a JSON file, returning undefined if the file does not exist.
+ */
 export async function safeReadJson<T>(path: string): Promise<T | undefined> {
   try {
     return await readJson<T>(path)
+  } catch {}
+}
+
+/**
+ * Read a file, returning undefined if the file does not exist.
+ */
+export async function safeReadFile(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, 'utf8')
   } catch {}
 }
 

--- a/test/config/ts-node.test.ts
+++ b/test/config/ts-node.test.ts
@@ -42,50 +42,48 @@ describe('tsPath', () => {
   })
 
   it('should resolve a .js file to ts src', async () => {
-    sandbox.stub(util, 'safeReadFile').resolves(JSON.stringify(DEFAULT_TS_CONFIG))
+    sandbox.stub(util, 'readTSConfig').resolves(DEFAULT_TS_CONFIG)
     const result = await configTsNode.tsPath(root, jsCompiled)
     expect(result).to.equal(join(root, tsModule))
   })
 
   it('should resolve a module file to ts src', async () => {
-    sandbox.stub(util, 'safeReadFile').resolves(JSON.stringify(DEFAULT_TS_CONFIG))
+    sandbox.stub(util, 'readTSConfig').resolves(DEFAULT_TS_CONFIG)
     const result = await configTsNode.tsPath(root, jsCompiledModule)
     expect(result).to.equal(join(root, tsModule))
   })
 
   it('should resolve a .ts file', async () => {
-    sandbox.stub(util, 'safeReadFile').resolves(JSON.stringify(DEFAULT_TS_CONFIG))
+    sandbox.stub(util, 'readTSConfig').resolves(DEFAULT_TS_CONFIG)
     const result = await configTsNode.tsPath(root, tsSource)
     expect(result).to.equal(join(root, tsSource))
   })
 
   it('should resolve a .ts file using baseUrl', async () => {
-    sandbox.stub(util, 'safeReadFile').resolves(
-      JSON.stringify({
-        compilerOptions: {
-          baseUrl: '.src/',
-          outDir: 'lib',
-        },
-      }),
-    )
+    sandbox.stub(util, 'readTSConfig').resolves({
+      compilerOptions: {
+        baseUrl: '.src/',
+        outDir: 'lib',
+      },
+    })
     const result = await configTsNode.tsPath(root, tsSource)
     expect(result).to.equal(join(root, tsSource))
   })
 
   it('should resolve .ts with no outDir', async () => {
-    sandbox.stub(util, 'safeReadFile').resolves(JSON.stringify({compilerOptions: {rootDir: 'src'}}))
+    sandbox.stub(util, 'readTSConfig').resolves({compilerOptions: {rootDir: 'src'}})
     const result = await configTsNode.tsPath(root, tsSource)
     expect(result).to.equal(join(root, tsSource))
   })
 
   it('should resolve .js with no rootDir and outDir', async () => {
-    sandbox.stub(util, 'safeReadFile').resolves(JSON.stringify({compilerOptions: {strict: true}}))
+    sandbox.stub(util, 'readTSConfig').resolves({compilerOptions: {strict: true}})
     const result = await configTsNode.tsPath(root, jsCompiled)
     expect(result).to.equal(join(root, jsCompiled))
   })
 
   it('should resolve to .ts file if enabled and prod', async () => {
-    sandbox.stub(util, 'safeReadFile').resolves(JSON.stringify(DEFAULT_TS_CONFIG))
+    sandbox.stub(util, 'readTSConfig').resolves(DEFAULT_TS_CONFIG)
     settings.tsnodeEnabled = true
     const originalNodeEnv = process.env.NODE_ENV
     delete process.env.NODE_ENV
@@ -98,7 +96,7 @@ describe('tsPath', () => {
   })
 
   it('should resolve to js if disabled', async () => {
-    sandbox.stub(util, 'safeReadFile').resolves(JSON.stringify(DEFAULT_TS_CONFIG))
+    sandbox.stub(util, 'readTSConfig').resolves(DEFAULT_TS_CONFIG)
     settings.tsnodeEnabled = false
     const result = await configTsNode.tsPath(root, jsCompiled)
     expect(result).to.equal(join(root, jsCompiled))

--- a/test/config/ts-node.test.ts
+++ b/test/config/ts-node.test.ts
@@ -1,11 +1,11 @@
 import {expect} from 'chai'
-import fs from 'node:fs/promises'
 import {join, resolve} from 'node:path'
 import {SinonSandbox, createSandbox} from 'sinon'
 import * as tsNode from 'ts-node'
 
 import * as configTsNode from '../../src/config/ts-node'
 import {Interfaces, settings} from '../../src/index'
+import * as util from '../../src/util/fs'
 
 const root = resolve(__dirname, 'fixtures/typescript')
 const tsSource = 'src/hooks/init.ts'
@@ -42,25 +42,25 @@ describe('tsPath', () => {
   })
 
   it('should resolve a .js file to ts src', async () => {
-    sandbox.stub(fs, 'readFile').resolves(JSON.stringify(DEFAULT_TS_CONFIG))
+    sandbox.stub(util, 'safeReadFile').resolves(JSON.stringify(DEFAULT_TS_CONFIG))
     const result = await configTsNode.tsPath(root, jsCompiled)
     expect(result).to.equal(join(root, tsModule))
   })
 
   it('should resolve a module file to ts src', async () => {
-    sandbox.stub(fs, 'readFile').resolves(JSON.stringify(DEFAULT_TS_CONFIG))
+    sandbox.stub(util, 'safeReadFile').resolves(JSON.stringify(DEFAULT_TS_CONFIG))
     const result = await configTsNode.tsPath(root, jsCompiledModule)
     expect(result).to.equal(join(root, tsModule))
   })
 
   it('should resolve a .ts file', async () => {
-    sandbox.stub(fs, 'readFile').resolves(JSON.stringify(DEFAULT_TS_CONFIG))
+    sandbox.stub(util, 'safeReadFile').resolves(JSON.stringify(DEFAULT_TS_CONFIG))
     const result = await configTsNode.tsPath(root, tsSource)
     expect(result).to.equal(join(root, tsSource))
   })
 
   it('should resolve a .ts file using baseUrl', async () => {
-    sandbox.stub(fs, 'readFile').resolves(
+    sandbox.stub(util, 'safeReadFile').resolves(
       JSON.stringify({
         compilerOptions: {
           baseUrl: '.src/',
@@ -73,19 +73,19 @@ describe('tsPath', () => {
   })
 
   it('should resolve .ts with no outDir', async () => {
-    sandbox.stub(fs, 'readFile').resolves(JSON.stringify({compilerOptions: {rootDir: 'src'}}))
+    sandbox.stub(util, 'safeReadFile').resolves(JSON.stringify({compilerOptions: {rootDir: 'src'}}))
     const result = await configTsNode.tsPath(root, tsSource)
     expect(result).to.equal(join(root, tsSource))
   })
 
   it('should resolve .js with no rootDir and outDir', async () => {
-    sandbox.stub(fs, 'readFile').resolves(JSON.stringify({compilerOptions: {strict: true}}))
+    sandbox.stub(util, 'safeReadFile').resolves(JSON.stringify({compilerOptions: {strict: true}}))
     const result = await configTsNode.tsPath(root, jsCompiled)
     expect(result).to.equal(join(root, jsCompiled))
   })
 
   it('should resolve to .ts file if enabled and prod', async () => {
-    sandbox.stub(fs, 'readFile').resolves(JSON.stringify(DEFAULT_TS_CONFIG))
+    sandbox.stub(util, 'safeReadFile').resolves(JSON.stringify(DEFAULT_TS_CONFIG))
     settings.tsnodeEnabled = true
     const originalNodeEnv = process.env.NODE_ENV
     delete process.env.NODE_ENV
@@ -98,7 +98,7 @@ describe('tsPath', () => {
   })
 
   it('should resolve to js if disabled', async () => {
-    sandbox.stub(fs, 'readFile').resolves(JSON.stringify(DEFAULT_TS_CONFIG))
+    sandbox.stub(util, 'safeReadFile').resolves(JSON.stringify(DEFAULT_TS_CONFIG))
     settings.tsnodeEnabled = false
     const result = await configTsNode.tsPath(root, jsCompiled)
     expect(result).to.equal(join(root, jsCompiled))


### PR DESCRIPTION
Always use `tsconfck` again for parse tsconfig.json

Fixes #849 