### PR TITLE
Add support to the NO_COLOR Manifest

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
 import write from './cli-ux/write'
 
+// learn about the no-color manifest in this link: https://no-color.org/
+// learn about how to disable chalks colors in this link: https://github.com/chalk/chalk#supportscolor
+process.env.FORCE_COLOR = (Number(!process.env.NO_COLOR) * 3).toString()
+
 function checkCWD() {
   try {
     process.cwd()


### PR DESCRIPTION
Add support to the [NO_COLOR manifest](https://no-color.org/).

- When `NO_COLOR` is set, chalk won't display any colors `FORCE_COLORS=0`
- When `NO_COLOR` is unset, chalk displays all possible colors `FORCE_COLORS=3`


CLI developers no longer need to create their own env variable to remove ansi colors from their command outputs. You can then include Heroku and SFDX CLIs in the NO_COLOR manifest opening a PR in this repo https://github.com/jcs/no_color