### PR TITLE
fix: improve plugin loading performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [3.10.5](https://github.com/oclif/core/compare/3.10.4...3.10.5) (2023-11-06)
+
+
+### Bug Fixes
+
+* extra parens in debug logs ([81c9efc](https://github.com/oclif/core/commit/81c9efcb1a042344761bbea01f12e54e39190c59))
+
+
+
 ## [3.10.4](https://github.com/oclif/core/compare/3.10.3...3.10.4) (2023-11-06)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oclif/core",
   "description": "base library for oclif CLIs",
-  "version": "3.10.4",
+  "version": "3.10.5",
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/core/issues",
   "dependencies": {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -19,6 +19,7 @@ import {getHomeDir, getPlatform} from '../util/os'
 import {compact, isProd} from '../util/util'
 import Cache from './cache'
 import PluginLoader from './plugin-loader'
+import {tsPath} from './ts-node'
 import {Debug, collectUsableIds, getCommandIdPermutations} from './util'
 
 // eslint-disable-next-line new-cap
@@ -511,7 +512,7 @@ export class Config implements IConfig {
         const marker = Performance.mark(OCLIF_MARKER_OWNER, `config.runHook#${p.name}(${hook})`)
         try {
           /* eslint-disable no-await-in-loop */
-          const {filePath, isESM, module} = await loadWithData(p, hook)
+          const {filePath, isESM, module} = await loadWithData(p, await tsPath(p.root, hook, p))
           debug('start', isESM ? '(import)' : '(require)', filePath)
 
           const result = timeout

--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -13,7 +13,7 @@ import {OCLIF_MARKER_OWNER, Performance} from '../performance'
 import {cacheCommand} from '../util/cache-command'
 import {findRoot} from '../util/find-root'
 import {readJson, requireJson} from '../util/fs'
-import {castArray, compact, isProd} from '../util/util'
+import {castArray, compact} from '../util/util'
 import {tsPath} from './ts-node'
 import {Debug, getCommandIdPermutations} from './util'
 
@@ -172,7 +172,6 @@ export class Plugin implements IPlugin {
     this.alias = this.options.name ?? this.pjson.name
     const pjsonPath = join(root, 'package.json')
     if (!this.name) throw new CLIError(`no name in ${pjsonPath}`)
-    if (!isProd() && !this.pjson.files) this.warn(`files attribute must be specified in ${pjsonPath}`)
     // eslint-disable-next-line new-cap
     this._debug = Debug(this.name)
     this.version = this.pjson.version

--- a/src/util/find-root.ts
+++ b/src/util/find-root.ts
@@ -28,11 +28,13 @@ function* up(from: string) {
 async function findPluginRoot(root: string, name?: string) {
   // If we know the plugin name then we just need to traverse the file
   // system until we find the directory that matches the plugin name.
+  debug.extend(name ?? 'root-plugin')(`Finding root starting at ${root}`)
   if (name) {
-    debug.extend(name)(`Finding root starting at ${root}`)
     for (const next of up(root)) {
-      debug.extend(name)(`Checking ${next}`)
-      if (next.endsWith(basename(name))) return next
+      if (next.endsWith(basename(name))) {
+        debug.extend(name)('Found root based on plugin name!')
+        return next
+      }
     }
   }
 
@@ -49,8 +51,11 @@ async function findPluginRoot(root: string, name?: string) {
 
     try {
       const cur = join(next, 'package.json')
-      debug.extend('root-plugin')(`Checking ${cur}`)
-      if (await safeReadJson<PJSON>(cur)) return dirname(cur)
+      debug.extend(name ?? 'root-plugin')(`Checking ${cur}`)
+      if (await safeReadJson<PJSON>(cur)) {
+        debug.extend(name ?? 'root-plugin')('Found root by traversing up from starting point!')
+        return dirname(cur)
+      }
     } catch {}
   }
 }


### PR DESCRIPTION
- Improves plugin loading perf by
  - defer running `tsPath` on hook paths until the hook needs to be executed
  - only load `commandsDir` if it's needed by `findCommand` or `getCommandIDs`
  - use the manifest to populate `this.commandIDs` if possible
- Remove unnecessary `files` check (Closes #851)
- Improve `find-root` debug logging