### PR TITLE
fix: removes empty files attribute warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [3.10.5](https://github.com/oclif/core/compare/3.10.4...3.10.5) (2023-11-06)
+
+
+### Bug Fixes
+
+* extra parens in debug logs ([81c9efc](https://github.com/oclif/core/commit/81c9efcb1a042344761bbea01f12e54e39190c59))
+
+
+
 ## [3.10.4](https://github.com/oclif/core/compare/3.10.3...3.10.4) (2023-11-06)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oclif/core",
   "description": "base library for oclif CLIs",
-  "version": "3.10.4",
+  "version": "3.10.5",
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/core/issues",
   "dependencies": {

--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -13,7 +13,7 @@ import {OCLIF_MARKER_OWNER, Performance} from '../performance'
 import {cacheCommand} from '../util/cache-command'
 import {findRoot} from '../util/find-root'
 import {readJson, requireJson} from '../util/fs'
-import {castArray, compact, isProd} from '../util/util'
+import {castArray, compact} from '../util/util'
 import {tsPath} from './ts-node'
 import {Debug, getCommandIdPermutations} from './util'
 
@@ -170,7 +170,6 @@ export class Plugin implements IPlugin {
     this.alias = this.options.name ?? this.pjson.name
     const pjsonPath = join(root, 'package.json')
     if (!this.name) throw new CLIError(`no name in ${pjsonPath}`)
-    if (!isProd() && !this.pjson.files) this.warn(`files attribute must be specified in ${pjsonPath}`)
     // eslint-disable-next-line new-cap
     this._debug = Debug(this.name)
     this.version = this.pjson.version


### PR DESCRIPTION
Removes a warning about an empty `files` attribute in the `package.json` file.

The warning is unnecessary, as it is valid not to have `files`, and use `.npmignore` instead to
specify what files should not be included in the package, and then include everything else by
default.

Closes #851
