### PR TITLE
fix: move up prod check in tsPath

### DIFF
--- a/src/config/ts-node.ts
+++ b/src/config/ts-node.ts
@@ -203,6 +203,12 @@ export async function tsPath(root: string, orig: string | undefined, plugin?: Pl
 
   const isProduction = isProd()
 
+  // Do not skip ts-node registration if the plugin is linked
+  if (settings.tsnodeEnabled === undefined && isProduction && plugin?.type !== 'link') {
+    debug(`Skipping ts-node registration for ${root} because NODE_ENV is NOT "test" or "development"`)
+    return orig
+  }
+
   if (cannotTranspileEsm(rootPlugin, plugin, isProduction)) {
     debug(
       `Skipping ts-node registration for ${root} because it's an ESM module (NODE_ENV: ${process.env.NODE_ENV}, root plugin module type: ${rootPlugin?.moduleType})`,
@@ -211,12 +217,6 @@ export async function tsPath(root: string, orig: string | undefined, plugin?: Pl
       memoizedWarn(
         `${plugin?.name} is a linked ESM module and cannot be auto-transpiled. Existing compiled source will be used instead.`,
       )
-    return orig
-  }
-
-  // Do not skip ts-node registration if the plugin is linked
-  if (settings.tsnodeEnabled === undefined && isProduction && plugin?.type !== 'link') {
-    debug(`Skipping ts-node registration for ${root} because NODE_ENV is NOT "test" or "development"`)
     return orig
   }
 

--- a/src/performance.ts
+++ b/src/performance.ts
@@ -194,7 +194,9 @@ export class Performance {
     if (!Performance.enabled) return
 
     const oclifDebug = require('debug')('oclif-perf')
-    oclifDebug('Total Time: %sms', Performance.oclifPerf['oclif.runMs'].toFixed(4))
+    const processUpTime = (process.uptime() * 1000).toFixed(4)
+    oclifDebug('Process Uptime: %sms', processUpTime)
+    oclifDebug('Oclif Time: %sms', Performance.oclifPerf['oclif.runMs'].toFixed(4))
     oclifDebug('Init Time: %sms', Performance.oclifPerf['oclif.initMs'].toFixed(4))
     oclifDebug('Config Load Time: %sms', Performance.oclifPerf['oclif.configLoadMs'].toFixed(4))
     oclifDebug(
@@ -227,6 +229,11 @@ export class Performance {
 
     oclifDebug('Command Load Time: %sms', Performance.oclifPerf['oclif.commandLoadMs'].toFixed(4))
     oclifDebug('Command Run Time: %sms', Performance.oclifPerf['oclif.commandRunMs'].toFixed(4))
+    if (Performance.oclifPerf['oclif.configLoadMs'] > Performance.oclifPerf['oclif.runMs']) {
+      oclifDebug(
+        '! Config load time is greater than total time. This might mean that Config was instantiated before oclif was run.',
+      )
+    }
 
     const nonCoreDebug = require('debug')('non-oclif-perf')
 

--- a/src/performance.ts
+++ b/src/performance.ts
@@ -200,6 +200,10 @@ export class Performance {
     oclifDebug('Init Time: %sms', Performance.oclifPerf['oclif.initMs'].toFixed(4))
     oclifDebug('Config Load Time: %sms', Performance.oclifPerf['oclif.configLoadMs'].toFixed(4))
     oclifDebug(
+      '  • Root Plugin Load Time: %sms',
+      Performance.getResult(OCLIF_MARKER_OWNER, 'plugin.load#root')?.duration.toFixed(4) ?? 0,
+    )
+    oclifDebug(
       '  • Plugins Load Time: %sms',
       Performance.getResult(OCLIF_MARKER_OWNER, 'config.loadAllPlugins')?.duration.toFixed(4) ?? 0,
     )

--- a/src/performance.ts
+++ b/src/performance.ts
@@ -231,7 +231,7 @@ export class Performance {
     oclifDebug('Command Run Time: %sms', Performance.oclifPerf['oclif.commandRunMs'].toFixed(4))
     if (Performance.oclifPerf['oclif.configLoadMs'] > Performance.oclifPerf['oclif.runMs']) {
       oclifDebug(
-        '! Config load time is greater than total time. This might mean that Config was instantiated before oclif was run.',
+        '! Config load time is greater than total oclif time. This might mean that Config was instantiated before oclif was run.',
       )
     }
 

--- a/test/perf/parser.perf.ts
+++ b/test/perf/parser.perf.ts
@@ -28,7 +28,7 @@ suite
   .add('multiple async flags that take time', {
     defer: true,
     fn(deferred: {resolve: () => any}) {
-      parse(['--flagA', 'foo', '--flagA', 'bar'], {
+      parse(['--flagA', 'foo', '--flagB', 'bar'], {
         flags: {
           flagA: Flags.string({
             async parse(input) {


### PR DESCRIPTION
- Moves up the `isProduction` check in `tsPath` so that the debug logs are more accurate about why ts-node registration is being skipped
- Adds `Process Uptime` perf debug log
- Renames `Total Time` debug log to `Oclif Time`
- Adds debug log to explain why `Config Load Time` could be greater than `Oclif Time`