### PR TITLE
feat: add flag type label

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -91,6 +91,7 @@ export class Config implements IConfig {
   public plugins: Map<string, IPlugin> = new Map()
   public root!: string
   public shell!: string
+  public showFlagTypeLabel!: boolean
   public topicSeparator: ' ' | ':' = ':'
   public userAgent!: string
   public userPJSON?: PJSON.User
@@ -324,6 +325,8 @@ export class Config implements IConfig {
     this.binPath = this.scopedEnvVar('BINPATH')
 
     this.npmRegistry = this.scopedEnvVar('NPM_REGISTRY') || this.pjson.oclif.npmRegistry
+
+    this.showFlagTypeLabel = this.pjson.oclif.showFlagTypeLabel || false
 
     this.pjson.oclif.update = this.pjson.oclif.update || {}
     this.pjson.oclif.update.node = this.pjson.oclif.update.node || {}

--- a/src/help/command.ts
+++ b/src/help/command.ts
@@ -147,8 +147,8 @@ export class CommandHelp extends HelpFormatter {
 
     if (flag.type === 'option') {
       let value
-      if (this.config.showFlagTypeLabel && flag.typeLabel) {
-        value = ` ${flag.typeLabel}`
+      if (this.config.showFlagTypeLabel) {
+        value = ` ${flag.typeLabel ?? 'string'}`
       } else {
         value = flag.helpValue || (this.opts.showFlagNameInTitle ? flag.name : '<value>')
         if (!flag.helpValue && flag.options) {

--- a/src/help/command.ts
+++ b/src/help/command.ts
@@ -145,7 +145,15 @@ export class CommandHelp extends HelpFormatter {
       label = labels.join(', ')
     }
 
-    if (flag.type === 'option') {
+    if (this.config.showFlagTypeLabel) {
+      label += ` ${
+        flag.typeLabel && flag.type === 'option'
+          ? flag.multiple
+            ? chalk.underline(flag.typeLabel)
+            : flag.typeLabel
+          : 'boolean'
+      }`
+    } else if (flag.type === 'option') {
       let value = flag.helpValue || (this.opts.showFlagNameInTitle ? flag.name : '<value>')
       if (!flag.helpValue && flag.options) {
         value = showOptions || this.opts.showFlagOptionsInTitle ? `${flag.options.join('|')}` : '<option>'

--- a/src/help/command.ts
+++ b/src/help/command.ts
@@ -145,23 +145,23 @@ export class CommandHelp extends HelpFormatter {
       label = labels.join(', ')
     }
 
-    if (this.config.showFlagTypeLabel) {
-      label += ` ${
-        flag.typeLabel && flag.type === 'option'
-          ? flag.multiple
-            ? chalk.underline(flag.typeLabel)
-            : flag.typeLabel
-          : 'boolean'
-      }`
-    } else if (flag.type === 'option') {
-      let value = flag.helpValue || (this.opts.showFlagNameInTitle ? flag.name : '<value>')
-      if (!flag.helpValue && flag.options) {
-        value = showOptions || this.opts.showFlagOptionsInTitle ? `${flag.options.join('|')}` : '<option>'
+    if (flag.type === 'option') {
+      let value
+      if (this.config.showFlagTypeLabel && flag.typeLabel) {
+        value = ` ${flag.typeLabel}`
+      } else {
+        value = flag.helpValue || (this.opts.showFlagNameInTitle ? flag.name : '<value>')
+        if (!flag.helpValue && flag.options) {
+          value = showOptions || this.opts.showFlagOptionsInTitle ? `${flag.options.join('|')}` : '<option>'
+        }
+
+        if (!value.includes('|')) value = chalk.underline(value)
+        value = `=${value}`
       }
 
       if (flag.multiple) value += '...'
-      if (!value.includes('|')) value = chalk.underline(value)
-      label += `=${value}`
+
+      label += value
     }
 
     return label

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -122,6 +122,7 @@ export interface Config {
    * active shell
    */
   readonly shell: string
+  readonly showFlagTypeLabel?: boolean
   topicSeparator: ' ' | ':'
   readonly topics: Topic[]
   /**

--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -178,6 +178,7 @@ export type FlagProps = {
    * For example: for a string flag
    *
    * FLAGS
+   *
    *   -r, --remote url
    *   -t, --team string
    *   -b, --buildpack url
@@ -218,8 +219,11 @@ export type ArgProps = {
    * For example: for a string arg
    *
    * ARGUMENTS
+   *
    *   APP string
+   *
    *   CERTIFICATE filePath
+   *
    *   BISCOITO naoEBolacha
    */
   typeLabel?: string
@@ -241,6 +245,7 @@ export type OptionFlagProps = FlagProps & {
    * separate on spaces.
    */
   delimiter?: ','
+  typeLabel?: string
 }
 
 export type FlagParserContext = Command & {token: FlagToken}

--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -170,6 +170,20 @@ export type FlagProps = {
    * This is helpful if the default value contains sensitive data that shouldn't be published to npm.
    */
   noCacheDefault?: boolean
+  /**
+   * The label for the type of the flag. When set, its value is appended after the flag's char and name.
+   * This is useful when developers want to quickly grasp the format of the value they must fill the flag with without
+   * the need of reading the flag's description.
+   *
+   * For example: for a string flag
+   *
+   * FLAGS
+   *   -r, --remote url
+   *   -t, --team string
+   *   -b, --buildpack url
+   *   -m, --metadatapath filePath
+   */
+  typeLabel?: string
 }
 
 export type ArgProps = {
@@ -196,6 +210,19 @@ export type ArgProps = {
    * This is helpful if the default value contains sensitive data that shouldn't be published to npm.
    */
   noCacheDefault?: boolean
+  /**
+   * The label for the type of the arg. When set, its value is appended after the arg's char and name.
+   * This is useful when developers want to quickly grasp the format of the value they must fill the arg
+   * without reading its description.
+   *
+   * For example: for a string arg
+   *
+   * ARGUMENTS
+   *   APP string
+   *   CERTIFICATE filePath
+   *   BISCOITO naoEBolacha
+   */
+  typeLabel?: string
 }
 
 export type BooleanFlagProps = FlagProps & {

--- a/src/interfaces/pjson.ts
+++ b/src/interfaces/pjson.ts
@@ -42,6 +42,7 @@ export namespace PJSON {
       plugins?: string[]
       repositoryPrefix?: string
       schema?: number
+      showFlagTypeLabel?: boolean
       state?: 'beta' | 'deprecated' | string
       topicSeparator?: ' ' | ':'
       topics?: {


### PR DESCRIPTION
This will enhance the way (flags | args) are displayed. Developers will no longer need to read the flag's description to grasp the type|format of value they have to use with a certain flag or arg. For example, when I read `filePath` I immediately understand that a certain flag require a file path.

Below you can see how docker cli does it

<img width="850" alt="image" src="https://github.com/oclif/core/assets/55927613/b47d93a0-48f6-4baf-b862-a8d62890e183">

obs: I added a new property called `typeLabel` instead of using the `helpValue` because I did not want to force cli developers to use it, and because the variable name better describe what it is than helpValue

## BEFORE

<img width="1592" alt="image" src="https://github.com/oclif/core/assets/55927613/87393767-d7dd-4d12-baef-bcf41446f448">

## AFTER

To enable this render type CLI developers have to set `oclif.showFlagTypeLabel` to `true` in the `package.json`

<img width="1595" alt="image" src="https://github.com/oclif/core/assets/55927613/4a65f892-4154-482c-b070-a274971c7ce2">




When `typeLabel` is not defined, and `oclif.showFlagTypeLabel` is true instead of showing `=<option>` it is displayed `string`, or `string...` if multiple. It feels cleaner in my opinion.

<img width="1593" alt="image" src="https://github.com/oclif/core/assets/55927613/af9a27ea-0d62-47d0-bc84-b635a2ee6851">


----

## When combining with the theme and indent features

<img width="1593" alt="image" src="https://github.com/oclif/core/assets/55927613/b7c22593-dfba-49c9-8641-fe91aa865d99">




