### PR TITLE
feat: improve flags indentation

### DIFF
--- a/src/help/command.ts
+++ b/src/help/command.ts
@@ -133,7 +133,7 @@ export class CommandHelp extends HelpFormatter {
 
     if (!label) {
       const labels = []
-      if (flag.char) labels.push(`-${flag.char[0]}`)
+      labels.push(flag.char ? `-${flag.char[0]}` : '  ')
       if (flag.name) {
         if (flag.type === 'boolean' && flag.allowNo) {
           labels.push(`--[no-]${flag.name.trim()}`)
@@ -142,7 +142,7 @@ export class CommandHelp extends HelpFormatter {
         }
       }
 
-      label = labels.join(', ')
+      label = labels.join(flag.char ? ', ' : '  ')
     }
 
     if (flag.type === 'option') {
@@ -162,8 +162,12 @@ export class CommandHelp extends HelpFormatter {
   protected flags(flags: Array<Command.Flag.Any>): [string, string | undefined][] | undefined {
     if (flags.length === 0) return
 
+    const noChar = flags.reduce((previous, current) => previous && current.char === undefined, true)
+
     return flags.map((flag) => {
-      const left = this.flagHelpLabel(flag)
+      let left = this.flagHelpLabel(flag)
+
+      if (noChar) left = left.replace('    ', '')
 
       let right = flag.summary || flag.description || ''
       if (flag.type === 'option' && flag.default) {
@@ -189,10 +193,14 @@ export class CommandHelp extends HelpFormatter {
         // Guaranteed to be set because of the filter above, but make ts happy
         const summary = flag.summary || ''
         let flagHelp = this.flagHelpLabel(flag, true)
+
+        if (!flag.char) flagHelp = flagHelp.replace('    ', '')
+
         flagHelp +=
           flagHelp.length + summary.length + 2 < this.opts.maxWidth
             ? '  ' + summary
             : '\n\n' + this.indent(this.wrap(summary, this.indentSpacing * 2))
+
         return `${flagHelp}\n\n${this.indent(this.wrap(flag.description || '', this.indentSpacing * 2))}`
       })
       .join('\n\n')

--- a/test/help/format-command-with-options.test.ts
+++ b/test/help/format-command-with-options.test.ts
@@ -53,10 +53,10 @@ OPTIONS
                        barfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar
   -l=label
   -r, --remote=remote
-  --force              force  it force  it force  it force  it force  it force
+      --force          force  it force  it force  it force  it force  it force
                        it force  it force  it force  it force  it force  it
                        force  it force  it force  it force  it
-  --ss                 newliney
+      --ss             newliney
                        newliney
                        newliney
                        newliney
@@ -106,10 +106,10 @@ OPTIONS
   -f, --foo=foo        foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoo
                        barfoobarfoobarfoobarfoobarfoobar
   -r, --remote=remote
-  --force              force  it force  it force  it force  it force  it force
+      --force          force  it force  it force  it force  it force  it force
                        it force  it force  it force  it force  it force  it
                        force  it force  it force  it force  it
-  --ss                 newliney
+      --ss             newliney
                        newliney
                        newliney
                        newliney

--- a/test/help/format-command.test.ts
+++ b/test/help/format-command.test.ts
@@ -55,10 +55,10 @@ FLAGS
                         obarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar
   -l=<value>
   -r, --remote=<value>
-  --force               force  it force  it force  it force  it force  it force
+      --force           force  it force  it force  it force  it force  it force
                         it force  it force  it force  it force  it force  it
                         force  it force  it force  it force  it
-  --ss                  newliney
+      --ss              newliney
                         newliney
                         newliney
                         newliney
@@ -115,10 +115,10 @@ FLAGS
   -f, --foo=<value>     foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfo
                         obarfoobarfoobarfoobarfoobarfoobar
   -r, --remote=<value>
-  --force               force  it force  it force  it force  it force  it force
+      --force           force  it force  it force  it force  it force  it force
                         it force  it force  it force  it force  it force  it
                         force  it force  it force  it force  it
-  --ss                  newliney
+      --ss              newliney
                         newliney
                         newliney
                         newliney


### PR DESCRIPTION
Indent flags with no char below each other, like docker cli does

<img width="871" alt="image" src="https://github.com/oclif/core/assets/55927613/a06a1e53-95ea-4280-a518-a7c0a8d82145">


### BEFORE
<img width="1518" alt="image" src="https://github.com/oclif/core/assets/55927613/7aaed690-276c-4ad6-875b-1ca68d947a96">



### AFTER

<img width="1536" alt="image" src="https://github.com/oclif/core/assets/55927613/9fc87e33-0216-49de-b61e-93ee780bbdff">

----

when combined with the theme feature this is the end result

<img width="1536" alt="image" src="https://github.com/oclif/core/assets/55927613/fc154cad-df63-4426-8b49-db41f1010c45">

<img width="1404" alt="image" src="https://github.com/oclif/core/assets/55927613/ab002136-f8ef-4c9b-b1bb-bf9eecee4961">





