### PR TITLE
feat: display help when NonExistentFlag exception is throw

### DIFF
--- a/src/help/util.ts
+++ b/src/help/util.ts
@@ -1,5 +1,6 @@
 import * as ejs from 'ejs'
 
+import {loadHelpClass} from '.'
 import {collectUsableIds} from '../config/util'
 import {Deprecation, Config as IConfig} from '../interfaces'
 
@@ -106,4 +107,10 @@ export function formatCommandDeprecationWarning(command: string, opts?: Deprecat
 export function normalizeArgv(config: IConfig, argv = process.argv.slice(2)): string[] {
   if (config.topicSeparator !== ':' && !argv[0]?.includes(':')) argv = standardizeIDFromArgv(argv, config)
   return argv
+}
+
+export async function showHelp(argv: string[], config: IConfig) {
+  const Help = await loadHelpClass(config)
+  const help = new Help(config, config.pjson.oclif.helpOptions ?? config.pjson.helpOptions)
+  return help.showHelp(argv)
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -92,12 +92,8 @@ export async function run(argv?: string[], options?: Interfaces.LoadOptions): Pr
   } catch (error) {
     // WARNING: error instanceof NonExistentFlag does not work
     // WARNING: typeof error === 'NonExistentFlag' does not work
-    if (error instanceof Error) {
-      // eslint-disable-next-line unicorn/no-lonely-if
-      if (error.message.includes('Nonexistent flag')) {
-        console.log(error)
-        await showHelp(argv, config)
-      }
+    if ((error as Error).message.includes('Nonexistent flag')) {
+      await showHelp(argv, config)
     }
   } finally {
     await collectPerf()

--- a/src/parser/errors.ts
+++ b/src/parser/errors.ts
@@ -20,7 +20,7 @@ export class CLIParseError extends CLIError {
   public parse: CLIParseErrorOptions['parse']
 
   constructor(options: CLIParseErrorOptions & {message: string}) {
-    options.message += '\nSee more help with --help'
+    options.message += '\nSee how the command can be used below:'
     super(options.message)
     this.parse = options.parse
   }

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -280,7 +280,7 @@ describe('parse', () => {
         expect(message).to.include(`Missing 2 required args:
 arg2  arg2 desc
 arg3  arg3 desc
-See more help with --help`)
+See how the command can be used below:`)
       })
 
       it('warns about having one flag with multiple values when missing an arg', async () => {
@@ -303,7 +303,7 @@ arg1  arg1 desc
 
 Note: --flag1 allows multiple values. Because of this you need to provide all arguments before providing that flag.
 Alternatively, you can use "--" to signify the end of the flags and the beginning of arguments.
-See more help with --help`)
+See how the command can be used below:`)
       })
 
       it('warns about having many flags with multiple values when missing an arg', async () => {
@@ -327,7 +327,7 @@ arg1  arg1 desc
 
 Note: --flag1, --flag2 allow multiple values. Because of this you need to provide all arguments before providing those flags.
 Alternatively, you can use "--" to signify the end of the flags and the beginning of arguments.
-See more help with --help`)
+See how the command can be used below:`)
       })
 
       it('too many args', async () => {
@@ -410,7 +410,7 @@ See more help with --help`)
 
         expect(message).to.include(`Missing 1 required arg:
 arg1
-See more help with --help`)
+See how the command can be used below:`)
       })
 
       it('two args: only first is required, only first has a default', async () => {
@@ -453,7 +453,7 @@ See more help with --help`)
         expect(message).to.include(`Invalid argument spec:
 arg1 (optional)
 arg2 (required)
-See more help with --help`)
+See how the command can be used below:`)
       })
 
       it('required arg after multiple optional args', async () => {
@@ -476,7 +476,7 @@ arg1 (optional)
 arg2 (optional)
 arg3 (optional)
 arg4 (required)
-See more help with --help`)
+See how the command can be used below:`)
       })
     })
 


### PR DESCRIPTION
ref: https://github.com/oclif/core/issues/679

With these changes the help message is displayed whenever a non existent flag is given

### BEFORE
<img width="1462" alt="image" src="https://github.com/oclif/core/assets/55927613/1a9c03af-8654-4afa-93da-795b2e274463">


### AFTER
<img width="1411" alt="image" src="https://github.com/oclif/core/assets/55927613/d2ef0aca-7636-49e8-99d8-28fab2ca9053">




### These changes do not affect required flags:
<img width="1462" alt="image" src="https://github.com/oclif/core/assets/55927613/2b196446-e15c-4e73-9d78-68461492cb37">

<img width="1470" alt="image" src="https://github.com/oclif/core/assets/55927613/8514530d-fb09-4af6-b187-8bdbfea93a57">

### These changes do not affect cli/plugin owner validations:
<img width="1463" alt="image" src="https://github.com/oclif/core/assets/55927613/3154678b-e48b-42f4-a1ff-dd008edb34b5">
