### PR TITLE
feat: add 'multipleNonGreedy' flag option to assign only one value per multiple flag

### DIFF
--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -209,6 +209,12 @@ export type OptionFlagProps = FlagProps & {
   options?: readonly string[]
   multiple?: boolean
   /**
+   * Parse one value per flag; allow `-m val1 -m val2`, disallow `-m val1 val2`.
+   * Set to true to use "multiple: true" flags together with args.
+   * Only respected if multiple is set to true.
+   */
+  multipleNonGreedy?: boolean
+  /**
    * Delimiter to separate the values for a multiple value flag.
    * Only respected if multiple is set to true. Default behavior is to
    * separate on spaces.

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -200,7 +200,7 @@ export class Parser<
         }
       }
 
-      if (parsingFlags && this.currentFlag && this.currentFlag.multiple) {
+      if (parsingFlags && this.currentFlag && this.currentFlag.multiple && !this.currentFlag.multipleNonGreedy) {
         this.raw.push({flag: this.currentFlag.name, input, type: 'flag'})
         continue
       }

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -631,6 +631,48 @@ See more help with --help`)
       })
     })
 
+    describe('multiple flags with single value', () => {
+      it('parses multiple flags with single value', async () => {
+        const out = await parse(['--bar', 'a', 'b', '--bar=c', '--baz=d', 'e'], {
+          args: {argOne: Args.string()},
+          flags: {
+            bar: Flags.string({multiple: true, multipleNonGreedy: true}),
+            baz: Flags.string({multiple: true}),
+          },
+        })
+        expect(out.flags.baz?.join('|')).to.equal('d|e')
+        expect(out.flags.bar?.join('|')).to.equal('a|c')
+        expect(out.args).to.deep.equal({argOne: 'b'})
+      })
+
+      it('parses multiple flags with single value multiple args', async () => {
+        const out = await parse(['c', '--bar', 'a', 'b'], {
+          args: {argOne: Args.string(), argTwo: Args.string()},
+          flags: {
+            bar: Flags.string({multiple: true, multipleNonGreedy: true}),
+          },
+        })
+        expect(out.flags.bar?.join('|')).to.equal('a')
+        expect(out.args).to.deep.equal({argOne: 'c', argTwo: 'b'})
+      })
+
+      it('fails to parse with single value and no args option', async () => {
+        let message = ''
+
+        try {
+          await parse(['--bar', 'a', 'b'], {
+            flags: {
+              bar: Flags.string({multiple: true, multipleNonGreedy: true}),
+            },
+          })
+        } catch (error: any) {
+          message = error.message
+        }
+
+        expect(message).to.include('Unexpected argument: b')
+      })
+    })
+
     describe('strict: false', () => {
       it('skips flag parsing after "--"', async () => {
         const out = await parse(['foo', 'bar', '--', '--myflag'], {


### PR DESCRIPTION
This is a port of https://github.com/oclif/parser/pull/79 by @cxam

Original description:

This feature aims to address the issue outlined in https://github.com/oclif/oclif/issues/190 to only allow a single value to be assigned for each flag that has the `multiple` option set. It's a non-breaking change that requires you to include the `singleValue` boolean in your flag options.

In the command `cmd -a foo bar`, it's generally accepted that `bar` becomes a positional argument and should be the default behaviour. Unfortunately, the [PR](https://github.com/oclif/parser/pull/25) that broke default behaviour has been part of this project for a while now and I feel providing the user an option to change this back would be the best course of action unless a breaking release is planned for oclif.

If this goes through, I'll update and push the relevant changes to the [docs repository](https://github.com/oclif/oclif.github.io).

