### PR TITLE
Fix this.log.bind(this)

### DIFF
--- a/src/cli-ux/README.md
+++ b/src/cli-ux/README.md
@@ -180,7 +180,7 @@ export default class Users extends Command {
         extended: true
       }
     }, {
-      printLine: this.log,
+      printLine: this.log.bind(this),
       ...flags, // parsed flags
     })
   }


### PR DESCRIPTION
This document is missing '. bind (this)'`, This can lead to the following errors:
```

TypeError: this.jsonEnabled is not a function
    at Object.log [as printLine] (/Users/user/xx-cli/node_modules/@oclif/core/lib/command.js:224:19)
    at Table.outputTable (/Users/user/xx-cli/node_modules/@oclif/core/lib/cli-ux/styled/table.js:244:21)
    at Table.display (/Users/user/xx-cli/node_modules/@oclif/core/lib/cli-ux/styled/table.js:137:22)
    at Object.table (/Users/user/xx-cli/node_modules/@oclif/core/lib/cli-ux/styled/table.js:301:39)
    at List.run (/Users/user/xx-cli/src/commands/list/index.ts:56:19)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async List._run (/Users/user/xx-cli/node_modules/@oclif/core/lib/command.js:304:22)
```
The official website is normal with the addition of '.bind(this)': https://oclif.io/docs/table