### PR TITLE
 fix: command not found on empty arg

### DIFF
--- a/src/help/util.ts
+++ b/src/help/util.ts
@@ -23,7 +23,7 @@ function collateSpacedCmdIDFromArgs(argv: string[], config: IConfig): string[] {
 
     const final: string[] = []
     const idPresent = (id: string) => ids.has(id)
-    const finalizeId = (s?: string) => (s ? [...final, s].join(':') : final.join(':'))
+    const finalizeId = (s?: string) => (s ? [...final, s] : final).filter(Boolean).join(':')
 
     const hasArgs = () => {
       const id = finalizeId()

--- a/test/help/util.test.ts
+++ b/test/help/util.test.ts
@@ -51,6 +51,12 @@ describe('util', () => {
       expect(actual).to.deep.equal(['foo:bar', '--baz'])
     })
 
+    test.it('should return standardized id when topic separator is a space', () => {
+      config.topicSeparator = ' '
+      const actual = standardizeIDFromArgv(['foo', '', '--baz'], config)
+      expect(actual).to.deep.equal(['foo', '', '--baz'])
+    })
+
     test
       .stub(util, 'collectUsableIds', (stub) => stub.returns(new Set(['foo', 'foo:bar'])))
       .it('should return standardized id when topic separator is a space', () => {


### PR DESCRIPTION
(this is a duplicate of #886 which had the wrong branch and was closed)

This PR fixes an edge case bug in command ID parsing when the topic separator is a space

When `argv` contains an empty string arg, the command ID extracted contains an extra colon.

An empty string arg can occur when running the CLI as part of a script.

Example:

```bash
set FOO=""
cli cmd ${FOO} --bar
```

Result: command not found "cmd"

Root cause: incorrect parsing in `standardizeIDFromArgv`, which for the above example returned `cmd:` as the command ID.