### PR TITLE
fix: command not found on empty arg (#887)

### DIFF
--- a/src/help/util.ts
+++ b/src/help/util.ts
@@ -23,7 +23,7 @@ function collateSpacedCmdIDFromArgs(argv: string[], config: IConfig): string[] {
 
     const final: string[] = []
     const idPresent = (id: string) => ids.has(id)
-    const finalizeId = (s?: string) => (s ? [...final, s].join(':') : final.join(':'))
+    const finalizeId = (s?: string) => (s ? [...final, s] : final).filter(Boolean).join(':')
 
     const hasArgs = () => {
       const id = finalizeId()

--- a/test/help/util.test.ts
+++ b/test/help/util.test.ts
@@ -51,6 +51,12 @@ describe('util', () => {
       expect(actual).to.deep.equal(['foo:bar', '--baz'])
     })
 
+    test.it('should return standardized id when topic separator is a space', () => {
+      config.topicSeparator = ' '
+      const actual = standardizeIDFromArgv(['foo', '', '--baz'], config)
+      expect(actual).to.deep.equal(['foo', '', '--baz'])
+    })
+
     test
       .stub(util, 'collectUsableIds', (stub) => stub.returns(new Set(['foo', 'foo:bar'])))
       .it('should return standardized id when topic separator is a space', () => {


### PR DESCRIPTION
Merges #887 

when `topicSeparator` is a space and an empty string arg is given, the searched command ID had an extra colon:

example:

```bash
set FOO=""
cli cmd ${FOO} --bar
```

result: command not found "cmd"

root cause: incorrect parsing in `standardizeIDFromArgv`, which for the above example returned `cmd:` as the command ID.