### PR TITLE
feat: allow stdin option for flags

### DIFF
--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -221,6 +221,10 @@ export type OptionFlagProps = FlagProps & {
    * separate on spaces.
    */
   delimiter?: ','
+  /**
+   * Allow input value to be read from stdin.
+   */
+  allowStdin?: boolean
 }
 
 export type FlagParserContext = Command & {token: FlagToken}


### PR DESCRIPTION
- Add option for flags: allowStdin
- If a value of '-' is provided, then read from stdin
- Based on solution provided in https://github.com/oclif/core/issues/761
- Does not solve for the situation in which a developer creates multiple flags with the allowStdin property
    - Based on above chatter, this should be up to the developer to provide a good experience