### PR TITLE
feat: allow theme file to be configurable

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -415,16 +415,12 @@ export class Config implements IConfig {
       await safeReadJson<Record<string, string>>(userThemeFile),
     ])
 
-    if (userTheme) {
-      return {
-        file: userThemeFile,
-        theme: parseTheme(userTheme),
-      }
-    }
-
     return {
-      file: defaultThemeFile,
-      theme: parseTheme(defaultTheme ?? {}),
+      // Point to the user file if it exists, otherwise use the default file.
+      // This doesn't really serve a purpose to anyone but removing it would be a breaking change.
+      file: userTheme ? userThemeFile : defaultThemeFile,
+      // Merge the default theme with the user theme, giving the user theme precedence.
+      theme: parseTheme({...defaultTheme, ...userTheme}),
     }
   }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -332,7 +332,7 @@ export class Config implements IConfig {
     this.npmRegistry = this.scopedEnvVar('NPM_REGISTRY') || this.pjson.oclif.npmRegistry
 
     if (!this.scopedEnvVarTrue('DISABLE_THEME')) {
-      const {theme} = await this.loadThemes()
+      const {theme} = await this.loadTheme()
       this.theme = theme
     }
 
@@ -401,16 +401,17 @@ export class Config implements IConfig {
     }
   }
 
-  public async loadThemes(): Promise<{
+  public async loadTheme(): Promise<{
     file: string
     theme: Theme | undefined
   }> {
-    const file = resolve(this.configDir, 'theme.json')
-    const themes = await safeReadJson<Record<string, string>>(file)
-    const theme = themes ? parseTheme(themes) : undefined
+    const file = this.pjson.oclif.theme
+      ? resolve(this.root, this.pjson.oclif.theme)
+      : resolve(this.configDir, 'theme.json')
+    const themeRaw = await safeReadJson<Record<string, string>>(file)
     return {
       file,
-      theme,
+      theme: themeRaw ? parseTheme(themeRaw) : undefined,
     }
   }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -415,12 +415,13 @@ export class Config implements IConfig {
       await safeReadJson<Record<string, string>>(userThemeFile),
     ])
 
+    // Merge the default theme with the user theme, giving the user theme precedence.
+    const merged = {...defaultTheme, ...userTheme}
     return {
       // Point to the user file if it exists, otherwise use the default file.
       // This doesn't really serve a purpose to anyone but removing it would be a breaking change.
       file: userTheme ? userThemeFile : defaultThemeFile,
-      // Merge the default theme with the user theme, giving the user theme precedence.
-      theme: parseTheme({...defaultTheme, ...userTheme}),
+      theme: Object.keys(merged).length > 0 ? parseTheme(merged) : undefined,
     }
   }
 

--- a/src/help/command.ts
+++ b/src/help/command.ts
@@ -161,7 +161,7 @@ export class CommandHelp extends HelpFormatter {
         }
       }
 
-      label = labels.join(colorize(this.config?.theme?.flagSeparator, flag.char ? ', ' : '  '))
+      label = labels.join(flag.char ? colorize(this.config?.theme?.flagSeparator, ', ') : '  ')
     }
 
     if (flag.type === 'option') {
@@ -175,7 +175,7 @@ export class CommandHelp extends HelpFormatter {
       label += `=${value}`
     }
 
-    return label
+    return colorize(this.config.theme?.flag, label)
   }
 
   protected flags(flags: Array<Command.Flag.Any>): [string, string | undefined][] | undefined {
@@ -184,7 +184,7 @@ export class CommandHelp extends HelpFormatter {
     const noChar = flags.reduce((previous, current) => previous && current.char === undefined, true)
 
     return flags.map((flag) => {
-      let left = colorize(this.config?.theme?.flag, this.flagHelpLabel(flag))
+      let left = this.flagHelpLabel(flag)
 
       if (noChar) left = left.replace('    ', '')
 

--- a/src/interfaces/pjson.ts
+++ b/src/interfaces/pjson.ts
@@ -43,15 +43,11 @@ export namespace PJSON {
         identifier?: string
         sign?: string
       }
-      windows?: {
-        homepage?: string
-        keypath?: string
-        name?: string
-      }
       plugins?: string[]
       repositoryPrefix?: string
       schema?: number
       state?: 'beta' | 'deprecated' | string
+      theme?: string
       topicSeparator?: ' ' | ':'
       topics?: {
         [k: string]: {
@@ -71,6 +67,11 @@ export namespace PJSON {
           options?: string | string[]
         }
         s3: S3
+      }
+      windows?: {
+        homepage?: string
+        keypath?: string
+        name?: string
       }
     }
     version: string


### PR DESCRIPTION
Allow the location of the `theme.json` to be configured by the root CLI's package.json. This allows CLIs to ship a theme to their users

```json
"files": ["theme.json"],
"oclif": {
  "theme": "./theme.json"
}
```

If users have their own theme at `~/.confg/<CLI>/theme.json` then it will be merged in with the default theme, with the user theme taking precedence. 

@W-14527856@