### PR TITLE
fix: cache stdin

### DIFF
--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -67,7 +67,7 @@ export const readStdin = async (): Promise<null | string> => {
     let result = ''
     const ac = new AbortController()
     const {signal} = ac
-    const timeout = setTimeout(() => ac.abort(), 100)
+    const timeout = setTimeout(() => ac.abort(), 10)
 
     const rl = createInterface({
       input: stdin,

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -61,9 +61,12 @@ export const readStdin = async (): Promise<null | string> => {
 
   if (stdin.isTTY) return null
 
-  return new Promise((resolve) => {
-    if (global.oclif?.stdinCache) resolve(global.oclif.stdinCache)
+  if (global.oclif?.stdinCache) {
+    debug('resolved stdin from global cache', global.oclif.stdinCache)
+    return global.oclif.stdinCache
+  }
 
+  return new Promise((resolve) => {
     let result = ''
     const ac = new AbortController()
     const {signal} = ac

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -62,7 +62,7 @@ export const readStdin = async (): Promise<null | string> => {
   if (stdin.isTTY) return null
 
   return new Promise((resolve) => {
-    if (global.oclif.stdinCache) resolve(global.oclif.stdinCache)
+    if (global.oclif?.stdinCache) resolve(global.oclif.stdinCache)
 
     let result = ''
     const ac = new AbortController()
@@ -82,7 +82,7 @@ export const readStdin = async (): Promise<null | string> => {
     rl.once('close', () => {
       clearTimeout(timeout)
       debug('resolved from stdin', result)
-      global.oclif.stdinCache = result
+      global.oclif = {...global.oclif, stdinCache: result}
       resolve(result)
     })
 

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -47,7 +47,7 @@ declare global {
    * in the dependency tree. Storing in a variable would only share the cache within the same version of @oclif/core.
    */
   // eslint-disable-next-line no-var
-  var stdinCache: string
+  var oclif: {stdinCache?: string}
 }
 
 export const readStdin = async (): Promise<null | string> => {
@@ -62,7 +62,7 @@ export const readStdin = async (): Promise<null | string> => {
   if (stdin.isTTY) return null
 
   return new Promise((resolve) => {
-    if (global.stdinCache) resolve(global.stdinCache)
+    if (global.oclif.stdinCache) resolve(global.oclif.stdinCache)
 
     let result = ''
     const ac = new AbortController()
@@ -82,7 +82,7 @@ export const readStdin = async (): Promise<null | string> => {
     rl.once('close', () => {
       clearTimeout(timeout)
       debug('resolved from stdin', result)
-      global.stdinCache = result
+      global.oclif.stdinCache = result
       resolve(result)
     })
 

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -140,6 +140,7 @@ export class Parser<
   public async parse(): Promise<ParserOutput<TFlags, BFlags, TArgs>> {
     this._debugInput()
 
+    // eslint-disable-next-line complexity
     const parseFlag = async (arg: string): Promise<boolean> => {
       const {isLong, name} = this.findFlag(arg)
       if (!name) {
@@ -168,6 +169,12 @@ export class Parser<
 
         this.currentFlag = flag
         let input = isLong || arg.length < 3 ? this.argv.shift() : arg.slice(arg[2] === '=' ? 3 : 2)
+
+        if (flag.allowStdin === 'only' && input !== '-' && input !== undefined) {
+          throw new CLIError(
+            `Flag --${name} can only be read from stdin. The value must be "-" or not provided at all.`,
+          )
+        }
 
         if ((flag.allowStdin && input === '-') || flag.allowStdin === 'only') {
           const stdin = await readStdin()

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -168,20 +168,17 @@ export class Parser<
 
         this.currentFlag = flag
         let input = isLong || arg.length < 3 ? this.argv.shift() : arg.slice(arg[2] === '=' ? 3 : 2)
-        // if the value ends up being one of the command's flags, the user didn't provide an input
-        if (typeof input !== 'string' || this.findFlag(input).name) {
-          throw new CLIError(`Flag --${name} expects a value`)
-        }
 
-        if (flag.allowStdin === 'only' && input !== '-') {
-          throw new CLIError(`Flag --${name} can only be read from stdin. The value must be "-".`)
-        }
-
-        if (flag.allowStdin && input === '-') {
+        if ((flag.allowStdin && input === '-') || flag.allowStdin === 'only') {
           const stdin = await readStdin()
           if (stdin) {
             input = stdin.trim()
           }
+        }
+
+        // if the value ends up being one of the command's flags, the user didn't provide an input
+        if (typeof input !== 'string' || this.findFlag(input).name) {
+          throw new CLIError(`Flag --${name} expects a value`)
         }
 
         this.raw.push({flag: flag.name, input, type: 'flag'})

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -1919,4 +1919,24 @@ describe('allowStdin', () => {
     expect(out.flags.myflag).to.equals(stdinValue)
     expect(out.raw[0].input).to.equal('x')
   })
+
+  it('should throw if allowStdin is "only" but value is not "-" or undefined', async () => {
+    sandbox.stub(parser, 'readStdin').returns(stdinPromise)
+    try {
+      await parse(['--myflag', 'INVALID'], {
+        flags: {
+          myflag: Flags.string({allowStdin: 'only'}),
+        },
+      })
+      expect.fail('Should have thrown an error')
+    } catch (error) {
+      if (error instanceof CLIError) {
+        expect(error.message).to.equal(
+          'Flag --myflag can only be read from stdin. The value must be "-" or not provided at all.',
+        )
+      } else {
+        expect.fail('Should have thrown a CLIError')
+      }
+    }
+  })
 })

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -1908,21 +1908,15 @@ describe('allowStdin', () => {
     expect(out.raw[0].input).to.equal('x')
   })
 
-  it('should throw if allowStdin is "only" but value is not "-"', async () => {
+  it('should read stdin as input for flag when allowStdin is "only" and no value is given', async () => {
     sandbox.stub(parser, 'readStdin').returns(stdinPromise)
-    try {
-      await parse(['--myflag', 'INVALID'], {
-        flags: {
-          myflag: Flags.string({allowStdin: 'only'}),
-        },
-      })
-      expect.fail('Should have thrown an error')
-    } catch (error) {
-      if (error instanceof CLIError) {
-        expect(error.message).to.equal('Flag --myflag can only be read from stdin. The value must be "-".')
-      } else {
-        expect.fail('Should have thrown a CLIError')
-      }
-    }
+    const out = await parse(['--myflag'], {
+      flags: {
+        myflag: Flags.string({allowStdin: 'only'}),
+      },
+    })
+
+    expect(out.flags.myflag).to.equals(stdinValue)
+    expect(out.raw[0].input).to.equal('x')
   })
 })


### PR DESCRIPTION
Currently, flags and args read from stdin are lost whenever `Parser.parse` is called multiple times. This PR caches the value read from stdin so that `Parser.parse` can be called multiple times.

This PR also:
- decreases timeout for reading stdin (from 100ms to 10ms)
- Flags with `allowStdin: 'only'` are no longer required to have `-` provided as the value (it's assumed)

@W-14954770@
https://github.com/forcedotcom/cli/issues/2690 