### PR TITLE
feat: add commandGlobPatterns option

### DIFF
--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -289,7 +289,7 @@ export class Plugin implements IPlugin {
 
     const marker = Performance.mark(OCLIF_MARKER_OWNER, `plugin.getCommandIDs#${this.name}`, {plugin: this.name})
     this._debug(`loading IDs from ${commandsDir}`)
-    const files = await globby(GLOB_PATTERNS, {cwd: commandsDir})
+    const files = await globby(this.pjson.oclif?.commandGlobPatterns ?? GLOB_PATTERNS, {cwd: commandsDir})
     const ids = processCommandIds(files)
     this._debug('found commands', ids)
     marker?.addDetails({count: ids.length})

--- a/src/interfaces/pjson.ts
+++ b/src/interfaces/pjson.ts
@@ -22,6 +22,11 @@ export namespace PJSON {
       additionalVersionFlags?: string[]
       aliases?: {[name: string]: null | string}
       commands?: string
+      /**
+       * Override the default globs for finding commands
+       * within the configured commands directory.
+       */
+      commandGlobPatterns?: string[]
       default?: string
       description?: string
       devPlugins?: string[]


### PR DESCRIPTION
Make the glob pattern for finding command files inside configured commands directory configurable. 

```json
{
  "oclif": {
     "commands": "./dist/commands",
     "commandGlobPatterns": [
       "**/*.command.*",
       "!**/*.+(d.*|test.*|spec.*|helpers.*)?(x)"
     ], 
  }
}
```

Fixes https://github.com/oclif/oclif/issues/1053
@W-15000333@