### PR TITLE
fix: only set timeout for TTY

### DIFF
--- a/src/cli-ux/prompt.ts
+++ b/src/cli-ux/prompt.ts
@@ -37,7 +37,7 @@ function normal(options: IPromptConfig, retries = 100): Promise<string> {
     })
     let timeout: NodeJS.Timeout
     // Only set the timeout if the input is a TTY
-    if (options.timeout && process.stdin.isTTY) {
+    if (options.timeout && options.isTTY) {
       timeout = setTimeout(() => ac.abort(), options.timeout)
       signal.addEventListener(
         'abort',

--- a/src/cli-ux/prompt.ts
+++ b/src/cli-ux/prompt.ts
@@ -36,7 +36,8 @@ function normal(options: IPromptConfig, retries = 100): Promise<string> {
       output: process.stdout,
     })
     let timeout: NodeJS.Timeout
-    if (options.timeout) {
+    // Only set the timeout if the input is a TTY
+    if (options.timeout && process.stdin.isTTY) {
       timeout = setTimeout(() => ac.abort(), options.timeout)
       signal.addEventListener(
         'abort',

--- a/test/cli-ux/prompt.test.ts
+++ b/test/cli-ux/prompt.test.ts
@@ -33,7 +33,7 @@ describe('prompt', () => {
     expect(answer).to.equal('answer')
   })
 
-  it('should not require input', async () => {
+  it('should not require input if required = false', async () => {
     stubReadline([''])
     const answer = await ux.prompt('Require input?', {required: false})
     expect(answer).to.equal('')
@@ -43,6 +43,16 @@ describe('prompt', () => {
     stubReadline([''])
     const answer = await ux.prompt('Require input?', {default: 'default'})
     expect(answer).to.equal('default')
+  })
+
+  it('should timeout after provided timeout', async () => {
+    stubReadline([''])
+    try {
+      await ux.prompt('Require input?', {timeout: 10})
+      expect.fail('should have thrown')
+    } catch (error: any) {
+      expect(error.message).to.equal('Prompt timeout')
+    }
   })
 
   it('should confirm with y', async () => {

--- a/test/cli-ux/prompt.test.ts
+++ b/test/cli-ux/prompt.test.ts
@@ -47,6 +47,7 @@ describe('prompt', () => {
 
   it('should timeout after provided timeout', async () => {
     stubReadline([''])
+    sandbox.stub(process, 'stdin').value({isTTY: true})
     try {
       await ux.prompt('Require input?', {timeout: 10})
       expect.fail('should have thrown')


### PR DESCRIPTION
Only set a timeout for a prompt if `process.stdin.TTY` is truthy

**QA**

1. checkout this branch and `yarn build`
2. `yarn && yarn build` in plugin-not-found directory
3. `yarn link @oclif/core` in plugin-not-found directory
4. `sf plugins link --no-install` in plugin-not-found directory
5. Test the following: 

Standard misspelled command scenario. Prompt should timeout after 10 seconds.
```
❯ time sf verson
 ›   Warning: @oclif/plugin-not-found is a linked ESM module and cannot be auto-transpiled. Existing compiled source will be used
 ›   instead.
 ›   Warning: verson is not a sf command.
Did you mean version? [y/n]:

 ›   Error: Run sf help for a list of available commands.
sf verson  0.55s user 0.09s system 6% cpu 10.429 total
```

Piping answer to prompt. Should not wait for timeout.
```
❯ echo y | sf verson
 ›   Warning: @oclif/plugin-not-found is a linked ESM module and cannot be auto-transpiled. Existing compiled source will be used
 ›   instead.
 ›   Warning: verson is not a sf command.
Did you mean version? [y/n]: y
@salesforce/cli/2.28.6 darwin-arm64 node-v20.11.0
```

Redirecting stdin to /dev/null should exit immediately with `0` exit code
```
❯ sf verson </dev/null
 ›   Warning: @oclif/plugin-not-found is a linked ESM module and cannot be auto-transpiled. Existing compiled source will be used
 ›   instead.
 ›   Warning: verson is not a sf command.
Did you mean version? [y/n]: %

❯ echo $?
0
```




@W-15100925@