### PR TITLE
fix: revert to original prompt implementation

### DIFF
--- a/src/cli-ux/prompt.ts
+++ b/src/cli-ux/prompt.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk'
-import readline from 'node:readline'
 
 import * as Errors from '../errors'
 import {config} from './config'
@@ -27,37 +26,26 @@ interface IPromptConfig {
 
 function normal(options: IPromptConfig, retries = 100): Promise<string> {
   if (retries < 0) throw new Error('no input')
-  const ac = new AbortController()
-  const {signal} = ac
-
   return new Promise((resolve, reject) => {
-    const rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    })
-    let timeout: NodeJS.Timeout
-    // Only set the timeout if the input is a TTY
-    if (options.timeout && options.isTTY) {
-      timeout = setTimeout(() => ac.abort(), options.timeout)
-      signal.addEventListener(
-        'abort',
-        () => {
-          rl.close()
-          clearTimeout(timeout)
-          reject(new Error('Prompt timeout'))
-        },
-        {once: true},
-      )
+    let timer: NodeJS.Timeout
+    if (options.timeout) {
+      timer = setTimeout(() => {
+        process.stdin.pause()
+        reject(new Error('Prompt timeout'))
+      }, options.timeout)
+      timer.unref()
     }
 
-    rl.question(options.prompt, {signal}, (answer) => {
-      rl.close()
-      const data = answer.trim()
+    process.stdin.setEncoding('utf8')
+    process.stderr.write(options.prompt)
+    process.stdin.resume()
+    process.stdin.once('data', (b) => {
+      if (timer) clearTimeout(timer)
+      process.stdin.pause()
+      const data: string = (typeof b === 'string' ? b : b.toString()).trim()
       if (!options.default && options.required && data === '') {
-        clearTimeout(timeout)
         resolve(normal(options, retries - 1))
       } else {
-        clearTimeout(timeout)
         resolve(data || (options.default as string))
       }
     })

--- a/test/cli-ux/prompt.test.ts
+++ b/test/cli-ux/prompt.test.ts
@@ -1,76 +1,73 @@
-import {expect} from 'chai'
-import readline from 'node:readline'
-import {SinonSandbox, createSandbox} from 'sinon'
+import * as chai from 'chai'
+
+const {expect} = chai
 
 import {ux} from '../../src/cli-ux'
+import {fancy} from './fancy'
 
 describe('prompt', () => {
-  let sandbox: SinonSandbox
-
-  function stubReadline(answers: string[]) {
-    let callCount = 0
-    sandbox.stub(readline, 'createInterface').returns({
-      // @ts-expect-error because we're stubbing
-      async question(_message, opts, cb) {
-        callCount += 1
-        cb(answers[callCount - 1])
-      },
-      close() {},
+  fancy
+    .stdout()
+    .stderr()
+    .end('requires input', async () => {
+      const promptPromise = ux.prompt('Require input?')
+      process.stdin.emit('data', '')
+      process.stdin.emit('data', 'answer')
+      const answer = await promptPromise
+      await ux.done()
+      expect(answer).to.equal('answer')
     })
-  }
 
-  beforeEach(() => {
-    sandbox = createSandbox()
-  })
+  fancy
+    .stdout()
+    .stderr()
+    .stdin('y')
+    .end('confirm', async () => {
+      const promptPromise = ux.confirm('yes/no?')
+      const answer = await promptPromise
+      await ux.done()
+      expect(answer).to.equal(true)
+    })
 
-  afterEach(() => {
-    sandbox.restore()
-  })
+  fancy
+    .stdout()
+    .stderr()
+    .stdin('n')
+    .end('confirm', async () => {
+      const promptPromise = ux.confirm('yes/no?')
+      const answer = await promptPromise
+      await ux.done()
+      expect(answer).to.equal(false)
+    })
 
-  it('should require input', async () => {
-    stubReadline(['', '', 'answer'])
-    const answer = await ux.prompt('Require input?')
-    expect(answer).to.equal('answer')
-  })
+  fancy
+    .stdout()
+    .stderr()
+    .stdin('x')
+    .end('gets anykey', async () => {
+      const promptPromise = ux.anykey()
+      const answer = await promptPromise
+      await ux.done()
+      expect(answer).to.equal('x')
+    })
 
-  it('should not require input if required = false', async () => {
-    stubReadline([''])
-    const answer = await ux.prompt('Require input?', {required: false})
-    expect(answer).to.equal('')
-  })
+  fancy
+    .stdout()
+    .stderr()
+    .end('does not require input', async () => {
+      const promptPromise = ux.prompt('Require input?', {
+        required: false,
+      })
+      process.stdin.emit('data', '')
+      const answer = await promptPromise
+      await ux.done()
+      expect(answer).to.equal('')
+    })
 
-  it('should use default input', async () => {
-    stubReadline([''])
-    const answer = await ux.prompt('Require input?', {default: 'default'})
-    expect(answer).to.equal('default')
-  })
-
-  it('should timeout after provided timeout', async () => {
-    stubReadline([''])
-    sandbox.stub(process, 'stdin').value({isTTY: true})
-    try {
-      await ux.prompt('Require input?', {timeout: 10})
-      expect.fail('should have thrown')
-    } catch (error: any) {
-      expect(error.message).to.equal('Prompt timeout')
-    }
-  })
-
-  it('should confirm with y', async () => {
-    stubReadline(['y'])
-    const answer = await ux.confirm('yes/no?')
-    expect(answer).to.equal(true)
-  })
-
-  it('should confirm with n', async () => {
-    stubReadline(['n'])
-    const answer = await ux.confirm('yes/no?')
-    expect(answer).to.equal(false)
-  })
-
-  it('should get anykey', async () => {
-    stubReadline(['x'])
-    const answer = await ux.anykey()
-    expect(answer).to.equal('x')
-  })
+  fancy
+    .stdout()
+    .stderr()
+    .it('timeouts with no input', async () => {
+      await expect(ux.prompt('Require input?', {timeout: 1})).to.eventually.be.rejectedWith('Prompt timeout')
+    })
 })


### PR DESCRIPTION
Revert the change made to `ux.prompt` by https://github.com/oclif/core/pull/953

This change resolved #952 but introduced other issues involving the prompt not timing in non-TTY environments. Since we plan to remove (or greatly reduce the functionality of) the `ux` module in the next major version, we're going to live with #952 for now. If people want a better prompt, then can switch to a dedicated library like inquirer.
