### PR TITLE
Proposal: Add custom plugin loader

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -375,6 +375,13 @@ export class Config implements IConfig {
     marker?.stop()
   }
 
+  public async loadCustomPlugins(root: string, plugins: string[]) {
+    const marker = Performance.mark(OCLIF_MARKER_OWNER, 'config.loadCustomPlugins')
+    await this.pluginLoader.loadCustomPlugins(root, plugins)
+    await this.loadPluginsAndCommands()
+    marker?.stop()
+  }
+
   async loadPluginsAndCommands(opts?: {force: boolean}): Promise<void> {
     const pluginsMarker = Performance.mark(OCLIF_MARKER_OWNER, 'config.loadAllPlugins')
     const {errors, plugins} = await this.pluginLoader.loadChildren({

--- a/src/config/plugin-loader.ts
+++ b/src/config/plugin-loader.ts
@@ -48,6 +48,10 @@ export default class PluginLoader {
     return {errors: this.errors, plugins: this.plugins}
   }
 
+  public async loadCustomPlugins(root: string, plugins: ({name?: string; root?: string; tag?: string; url?: string} | string)[],): Promise<void> {
+    await this.loadPlugins(root, 'custom', plugins)
+  }
+
   public async loadRoot(): Promise<IPlugin> {
     let rootPlugin: IPlugin
     if (this.pluginsProvided) {


### PR DESCRIPTION
At Shopify we want to be able to dynamically load our own plugins for a very specific use case:


>If you are running a global CLI in a folder with a package.json, and that package.json
 has a dependency on something like `@shopify/*`, try to load that as a plugin.

That way plugins can be defined per project just as normal dependencies. (without adding an `oclif` entry in package.json)

--- 
We were doing this with `oclif v2` by subclassing `Config` and overriding the `loadCorePlugins()`. You can see how [here](https://github.com/Shopify/cli/blob/global-cli/packages/cli-kit/src/public/node/custom-oclif-loader.ts).

This is not possible in `oclif v3` because `loadCorePlugins` no longer exists and everything is abstracted in the PluginLoader.

This PR is a simple proposal to expose a method that would let us load custom plugins that are not defined in our package.json (or anywhere).

Please let me know if this is a valid approach or you'd prefer to do this in a different way.

