### PR TITLE
Fix: correctly escapes double quotes when converting ux.table to csv

### DIFF
--- a/src/cli-ux/styled/table.ts
+++ b/src/cli-ux/styled/table.ts
@@ -150,7 +150,7 @@ class Table<T extends Record<string, unknown>> {
     const lineToBeEscaped = values.find(
       (e: string) => e.includes('"') || e.includes('\n') || e.includes('\r\n') || e.includes('\r') || e.includes(','),
     )
-    return values.map((e) => (lineToBeEscaped ? `"${e.replace('"', '""')}"` : e))
+    return values.map((e) => (lineToBeEscaped ? `"${e.replaceAll('"', '""')}"` : e))
   }
 
   private outputCSV() {

--- a/test/cli-ux/styled/table.test.ts
+++ b/test/cli-ux/styled/table.test.ts
@@ -159,12 +159,16 @@ describe('styled/table', () => {
             name: 'supertable-test-2',
           },
           {
-            id: '123',
-            name: 'supertable-test-3,comma',
+            id: '1"2"3',
+            name: 'supertable-test-3',
           },
           {
             id: '123',
-            name: 'supertable-test-4',
+            name: 'supertable-test-4,comma',
+          },
+          {
+            id: '123',
+            name: 'supertable-test-5',
           },
         ],
         columns,
@@ -173,8 +177,9 @@ describe('styled/table', () => {
       expect(output.stdout).to.equal(`ID,Name
 "123\n2","supertable-test-1"
 "12""3","supertable-test-2"
-"123","supertable-test-3,comma"
-123,supertable-test-4\n`)
+"1""2""3","supertable-test-3"
+"123","supertable-test-4,comma"
+123,supertable-test-5\n`)
     })
 
     fancy.stdout().end('outputs in csv without headers', (output) => {


### PR DESCRIPTION
modify replace with replaceAll as mentioned in this issue : https://github.com/oclif/core/issues/944#issue-2126189996