### PR TITLE
feat: support plugins with wildcards

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "indent-string": "^4.0.0",
     "is-wsl": "^2.2.0",
     "js-yaml": "^3.14.1",
+    "minimatch": "^9.0.3",
     "natural-orderby": "^2.0.3",
     "object-treeify": "^1.1.33",
     "password-prompt": "^1.1.3",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -381,6 +381,7 @@ export class Config implements IConfig {
       dataDir: this.dataDir,
       devPlugins: this.options.devPlugins,
       force: opts?.force ?? false,
+      pluginAdditions: this.options.pluginAdditions,
       rootPlugin: this.rootPlugin,
       userPlugins: this.options.userPlugins,
     })

--- a/src/interfaces/plugin.ts
+++ b/src/interfaces/plugin.ts
@@ -22,6 +22,11 @@ export interface Options extends PluginOptions {
   devPlugins?: boolean
   enablePerf?: boolean
   jitPlugins?: boolean
+  pluginAdditions?: {
+    core?: string[]
+    dev?: string[]
+    path?: string
+  }
   plugins?: Map<string, Plugin>
   userPlugins?: boolean
   version?: string

--- a/test/config/fixtures/wildcard/package.json
+++ b/test/config/fixtures/wildcard/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "wildcard-plugins-fixture",
+  "version": "0.0.0",
+  "description": "fixture for testing wildcard plugins",
+  "private": true,
+  "files": [],
+  "dependencies": {
+    "@oclif/core": "^3",
+    "@oclif/plugin-help": "^6",
+    "@oclif/plugin-plugins": "^4"
+  },
+  "oclif": {
+    "commands": "./lib/commands",
+    "topicSeparator": " ",
+    "plugins": [
+      "@oclif/plugin-*"
+    ]
+  }
+}

--- a/test/config/fixtures/wildcard/src/commands/foo.ts
+++ b/test/config/fixtures/wildcard/src/commands/foo.ts
@@ -1,0 +1,8 @@
+import {Command} from '../../../../../../src/index'
+
+export default class Foo extends Command {
+  public static description = 'foo description'
+  public async run(): Promise<void> {
+    this.log('hello world!')
+  }
+}

--- a/test/config/fixtures/wildcard/tsconfig.json
+++ b/test/config/fixtures/wildcard/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDirs": ["./src"]
+  },
+  "include": ["./src/**/*"]
+}

--- a/test/config/wildcard-plugins.test.ts
+++ b/test/config/wildcard-plugins.test.ts
@@ -1,0 +1,56 @@
+import {expect} from 'chai'
+import {resolve} from 'node:path'
+import {SinonSandbox, createSandbox} from 'sinon'
+
+import {run, ux} from '../../src/index'
+
+describe('plugins defined as patterns in package.json', () => {
+  let sandbox: SinonSandbox
+
+  beforeEach(() => {
+    sandbox = createSandbox()
+    sandbox.stub(ux.write, 'stdout')
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it('should load all core plugins in dependencies that match pattern', async () => {
+    const result = (await run(['plugins', '--core'], {
+      root: resolve(__dirname, 'fixtures/wildcard/package.json'),
+      pluginAdditions: {
+        core: ['@oclif/plugin-*'],
+        path: resolve(__dirname, '..', '..'),
+      },
+    })) as Array<{name: string; type: string}>
+
+    expect(result.length).to.equal(3)
+    const rootPlugin = result.find((r) => r.name === 'wildcard-plugins-fixture')
+    const pluginHelp = result.find((r) => r.name === '@oclif/plugin-help')
+    const pluginPlugins = result.find((r) => r.name === '@oclif/plugin-plugins')
+
+    expect(rootPlugin).to.exist
+    expect(pluginHelp).to.exist
+    expect(pluginPlugins).to.exist
+  })
+
+  it('should load all dev plugins in dependencies and devDependencies that match pattern', async () => {
+    const result = (await run(['plugins', '--core'], {
+      root: resolve(__dirname, 'fixtures/wildcard/package.json'),
+      pluginAdditions: {
+        dev: ['@oclif/plugin-*'],
+        path: resolve(__dirname, '..', '..'),
+      },
+    })) as Array<{name: string; type: string}>
+
+    expect(result.length).to.equal(3)
+    const rootPlugin = result.find((r) => r.name === 'wildcard-plugins-fixture')
+    const pluginHelp = result.find((r) => r.name === '@oclif/plugin-help')
+    const pluginPlugins = result.find((r) => r.name === '@oclif/plugin-plugins')
+
+    expect(rootPlugin).to.exist
+    expect(pluginHelp).to.exist
+    expect(pluginPlugins).to.exist
+  })
+})


### PR DESCRIPTION
Allow plugins to be defined with [minimatch](https://www.npmjs.com/package/minimatch) patterns. For instance: 

```json
{
  "dependencies": {
    "@oclif/core": "^3",
    "@oclif/plugin-help": "^6",
    "@oclif/plugin-plugins": "^4",
    "@org/cool-plugin": "^1",
    "@org/awesome-plugin": "^1",
   },
  "oclif": {
    "plugins": [
        "@oclif/plugin-*",
        "@org/*",
     ]
  }
}
```

This PR also exposes a new option on `Config` called `pluginAdditions` that informs `Config` of additional plugins that should be loaded. This is solves the use case described in https://github.com/oclif/core/pull/976

`pluginAdditions` is defined as:
```
  pluginAdditions?: {
    core?: string[] // core plugins that should be loaded
    dev?: string[] // dev plugins that should be loaded
    path?: string // path to load these plugins from (defaults to root plugin's path)
  }
```

Example:
```typescript
  const config = new Config({
    pluginAdditions: {
      core: ['@oclif/plugin-*'],
    },
    root: __dirname,
  })
  await config.load()
```

**QA**
- checkout branch and `yarn && yarn build`
- `oclif generate my-cli`
- `cd my-cli && yarn link @oclif/core`
- Change `plugins` entry in package.json to `"plugins": ["@oclif/plugin-*"]`
- `bin/dev.js` should should `help` and `plugins` topics 
- `bin/dev.js plugins --core` should show plugin-help and plugin-plugins
- remove `plugins` from package.json
- change `bin/run.js` to:
```javascript
#!/usr/bin/env node

// eslint-disable-next-line unicorn/prefer-top-level-await
;(async () => {
  const {execute} = await import('@oclif/core')
  await execute({
    loadOptions: {
      pluginAdditions: {
        core: ['@oclif/plugin-*'],
      },
      root: __dirname,
    },
  })
})()
```
- `bin/dev.js` should should `help` and `plugins` topics 
- `bin/dev.js plugins --core` should show plugin-help and plugin-plugins
- `oclif generate another-cli`
- `cd another-cli && yarn add @oclif/plugin-version`
- change `bin/dev.js` of `my-cli` to:
```javascript
#!/usr/bin/env node

// eslint-disable-next-line unicorn/prefer-top-level-await
;(async () => {
  const {execute} = await import('@oclif/core')
  await execute({
    loadOptions: {
      pluginAdditions: {
        core: ['@oclif/plugin-*'],
        path: 'path/to/another-cli'
      },
      root: __dirname,
    },
  })
})()
```
- `bin/dev.js` should should `help`, `plugins`, and `version` topics/commands 
- `bin/dev.js plugins --core` should show plugin-help, plugin-plugins, and plugin-version

Closes #976 
Closes https://github.com/oclif/oclif/discussions/1235