### PR TITLE
fix: allow arg to be empty string

### DIFF
--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -305,7 +305,7 @@ export class Parser<
     }
 
     for (const token of tokens) {
-      if (args[token.arg]) continue
+      if (args[token.arg] !== undefined) continue
       argv.push(token.input)
     }
 

--- a/src/parser/validate.ts
+++ b/src/parser/validate.ts
@@ -44,7 +44,8 @@ export async function validate(parse: {input: ParserInput; output: ParserOutput}
         })
       }
 
-      if (arg.required && !parse.output.args[name] && parse.output.args[name] !== 0) {
+      // Only add if it's required and undefined. Allow falsy values like empty strings and 0.
+      if (arg.required && parse.output.args[name] === undefined) {
         missingRequiredArgs.push(arg)
       }
     }

--- a/test/parser/validate.test.ts
+++ b/test/parser/validate.test.ts
@@ -121,6 +121,31 @@ describe('validate', () => {
     await validate({input, output})
   })
 
+  it('allows empty string as arg', async () => {
+    const input = {
+      argv: [],
+      flags: {},
+      args: {
+        emptyString: {required: true},
+      },
+      strict: true,
+      context: {},
+      '--': true,
+    }
+
+    const output = {
+      args: {emptyString: ''},
+      argv: [''],
+      raw: [],
+      metadata: {
+        flags: {},
+      },
+    }
+
+    // @ts-expect-error
+    await validate({input, output})
+  })
+
   it('throws when required flag is undefined', async () => {
     const input = {
       argv: [],


### PR DESCRIPTION
Allow args to be an empty string, e.g. `my-cli hello ''`

Fixes #982 
@W-15161625@