### PR TITLE
feat: deprecate ux module

### DIFF
--- a/src/cli-ux/action/base.ts
+++ b/src/cli-ux/action/base.ts
@@ -11,6 +11,9 @@ export interface ITask {
 
 export type ActionType = 'debug' | 'simple' | 'spinner'
 
+/**
+ * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+ */
 export class ActionBase {
   std: 'stderr' | 'stdout' = 'stderr'
 

--- a/src/cli-ux/config.ts
+++ b/src/cli-ux/config.ts
@@ -23,6 +23,9 @@ const actionType =
 
 const Action = actionType === 'spinner' ? spinner : simple
 
+/**
+ * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+ */
 export class Config {
   action: ActionBase = new Action()
 
@@ -57,5 +60,8 @@ function fetch() {
   return globals[major]
 }
 
+/**
+ * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+ */
 export const config: Config = fetch()
 export default config

--- a/src/cli-ux/index.ts
+++ b/src/cli-ux/index.ts
@@ -147,28 +147,97 @@ const {
 const {error, exit, warn} = Errors
 
 export {
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   action,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   annotation,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   anykey,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   confirm,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   debug,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   done,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   error,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   exit,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   flush,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   info,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   log,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   logToStderr,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   progress,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   prompt,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   styledHeader,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   styledJSON,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   styledObject,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   table,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   trace,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   tree,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   url,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   wait,
+  /**
+   * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+   */
   warn,
 }
 

--- a/src/cli-ux/prompt.ts
+++ b/src/cli-ux/prompt.ts
@@ -3,6 +3,9 @@ import chalk from 'chalk'
 import * as Errors from '../errors'
 import {config} from './config'
 
+/**
+ * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+ */
 export interface IPromptOptions {
   default?: string
   prompt?: string

--- a/src/cli-ux/styled/table.ts
+++ b/src/cli-ux/styled/table.ts
@@ -11,6 +11,9 @@ import {stdtermwidth} from '../../screen'
 import {capitalize, sumBy} from '../../util/util'
 import write from '../write'
 
+/**
+ * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+ */
 class Table<T extends Record<string, unknown>> {
   columns: (table.Column<T> & {key: string; maxWidth?: number; width?: number})[]
 

--- a/src/cli-ux/write.ts
+++ b/src/cli-ux/write.ts
@@ -6,6 +6,9 @@ const stderr = (msg: string): void => {
   process.stderr.write(msg)
 }
 
+/**
+ * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+ */
 export default {
   stderr,
   stdout,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import * as cliUx from './cli-ux'
 import write from './cli-ux/write'
 
 function checkCWD() {
@@ -14,12 +13,7 @@ function checkCWD() {
 checkCWD()
 
 export * as Args from './args'
-/**
- * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
- */
-export const ux = {
-  ...cliUx,
-}
+export * as ux from './cli-ux'
 export {flush} from './cli-ux/flush'
 export {stderr, stdout} from './cli-ux/stream' // Remove these in the next major version
 export {Command} from './command'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import * as cliUx from './cli-ux'
 import write from './cli-ux/write'
 
 function checkCWD() {
@@ -13,7 +14,12 @@ function checkCWD() {
 checkCWD()
 
 export * as Args from './args'
-export * as ux from './cli-ux'
+/**
+ * @deprecated `ux` will be removed in the next major. See https://github.com/oclif/core/discussions/999
+ */
+export const ux = {
+  ...cliUx,
+}
 export {flush} from './cli-ux/flush'
 export {stderr, stdout} from './cli-ux/stream' // Remove these in the next major version
 export {Command} from './command'


### PR DESCRIPTION
Mark `ux` module as deprecated. See https://github.com/oclif/core/discussions/999 for context.