### PR TITLE
feat: add preparse hook

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -29,6 +29,7 @@ const debug = Debug()
 
 const _pjson = Cache.getInstance().get('@oclif/core')
 const BASE = `${_pjson.name}@${_pjson.version}`
+const ROOT_ONLY_HOOKS = new Set<keyof Hooks>(['preparse'])
 
 function channelFromVersion(version: string) {
   const m = version.match(/[^-]+(?:-([^.]+))?/)
@@ -530,7 +531,9 @@ export class Config implements IConfig {
       failures: [],
       successes: [],
     } as Hook.Result<Hooks[T]['return']>
-    const promises = [...this.plugins.values()].map(async (p) => {
+
+    const plugins = ROOT_ONLY_HOOKS.has(event) ? [this.rootPlugin] : [...this.plugins.values()]
+    const promises = plugins.map(async (p) => {
       const debug = require('debug')([this.bin, p.name, 'hooks', event].join(':'))
       const context: Hook.Context = {
         config: this,

--- a/src/interfaces/hooks.ts
+++ b/src/interfaces/hooks.ts
@@ -1,5 +1,6 @@
 import {Command} from '../command'
 import {Config} from './config'
+import {Input, OutputFlags} from './parser'
 import {Plugin} from './plugin'
 
 interface HookMeta {
@@ -46,6 +47,13 @@ export interface Hooks {
       result?: any
     }
     return: void
+  }
+  preparse: {
+    options: {
+      argv: string[]
+      options: Input<OutputFlags<any>, OutputFlags<any>, OutputFlags<any>>
+    }
+    return: string[]
   }
   prerun: {
     options: {Command: Command.Class; argv: string[]}

--- a/test/parser/fixtures/preparse-plugin/package.json
+++ b/test/parser/fixtures/preparse-plugin/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "preparse-plugin",
+  "private": true,
+  "files": [],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "oclif": {
+    "commands": "./lib/commands",
+    "hooks": {
+      "preparse": "./lib/hooks/preparse.js"
+    }
+  }
+}

--- a/test/parser/fixtures/preparse-plugin/src/commands/test.ts
+++ b/test/parser/fixtures/preparse-plugin/src/commands/test.ts
@@ -1,0 +1,64 @@
+import {Command, Flags, Interfaces} from '../../../../../../src'
+import {BooleanFlag} from '../../../../../../src/interfaces'
+
+type GroupAliasOption = {
+  flag: string
+  option?: string
+}
+
+function groupAliasFlag<T = boolean>(
+  options: Partial<BooleanFlag<T> & {groupAlias: GroupAliasOption[]}> = {},
+): BooleanFlag<T> {
+  return {
+    parse: async (b, _) => b,
+    ...options,
+    allowNo: Boolean(options.allowNo),
+    type: 'boolean',
+  } as BooleanFlag<T>
+}
+
+export default class Test extends Command {
+  static args = {}
+
+  static flags = {
+    burger: Flags.string({
+      char: 'b',
+      default: async () => 'double',
+    }),
+    combo: groupAliasFlag({
+      char: 'c',
+      groupAlias: [
+        {flag: 'burger'},
+        {flag: 'fries'},
+        {
+          flag: 'shake',
+          option: 'strawberry',
+        },
+      ],
+    }),
+    shake: Flags.option({
+      options: ['chocolate', 'vanilla', 'strawberry'],
+      char: 's',
+    })(),
+    fries: Flags.boolean({
+      allowNo: true,
+      char: 'f',
+    }),
+    'flags-dir': Flags.directory(),
+    sauce: Flags.string({
+      multiple: true,
+      default: ['ketchup'],
+    }),
+  }
+
+  async run(): Promise<{
+    args: Interfaces.InferredArgs<typeof Test.args>
+    flags: Interfaces.InferredFlags<typeof Test.flags>
+  }> {
+    const {args, flags} = await this.parse(Test)
+    return {
+      args,
+      flags,
+    }
+  }
+}

--- a/test/parser/fixtures/preparse-plugin/src/hooks/preparse.ts
+++ b/test/parser/fixtures/preparse-plugin/src/hooks/preparse.ts
@@ -1,0 +1,81 @@
+import {readFile, readdir} from 'node:fs/promises'
+import {join, parse} from 'node:path'
+
+import {Hook} from '../../../../../../src'
+
+const hook: Hook<'preparse'> = async function ({argv, options}) {
+  const flagsToIgnore = new Set(
+    Object.entries(options.flags ?? {})
+      .filter(
+        ([_, flagOptions]) =>
+          // don't ignore if flag can take multiple values
+          (flagOptions.type === 'option' && flagOptions.multiple !== true) || flagOptions.type === 'boolean',
+      )
+      .filter(
+        ([flagName, flagOptions]) =>
+          // ignore if short char flag is present
+          argv.includes(`-${flagOptions.char}`) ||
+          // ignore if long flag is present
+          argv.includes(`--${flagName}`) ||
+          // ignore if --no- flag is present
+          (flagOptions.type === 'boolean' && flagOptions.allowNo && argv.includes(`--no-${flagName}`)),
+      )
+      .map(([flagName]) => flagName),
+  )
+
+  const groupAliasFlags = Object.fromEntries(
+    Object.entries(options.flags ?? {}).filter(
+      ([_, flagOptions]) =>
+        // @ts-expect-error because the type isn't aware of the custom flag we made
+        flagOptions.groupAlias,
+    ),
+  )
+
+  for (const [flagName, flagOptions] of Object.entries(groupAliasFlags)) {
+    const groupAliasFlagPresent = argv.includes(`--${flagName}`) || argv.includes(`-${flagOptions.char}`)
+
+    if (groupAliasFlagPresent) {
+      // @ts-expect-error because the type isn't aware of the custom flag we made
+      for (const groupAliasOption of flagOptions.groupAlias) {
+        if (flagsToIgnore.has(groupAliasOption.flag)) continue
+        argv.push(`--${groupAliasOption.flag}`)
+        if (groupAliasOption.option) argv.push(groupAliasOption.option)
+        if (typeof options.flags?.[groupAliasOption.flag].default === 'function') {
+          // eslint-disable-next-line no-await-in-loop
+          argv.push(await options.flags?.[groupAliasOption.flag].default())
+          continue
+        }
+
+        if (options.flags?.[groupAliasOption.flag].default) {
+          argv.push(options.flags?.[groupAliasOption.flag].default)
+        }
+      }
+    }
+  }
+
+  if (argv.includes('--flags-dir')) {
+    const flagsDir = argv[argv.indexOf('--flags-dir') + 1]
+    const filesInDir = await readdir(flagsDir)
+    const flagsToInsert = await Promise.all(
+      filesInDir
+        // ignore files that were provided as flags
+        .filter((f) => !flagsToIgnore.has(f))
+        .map(async (file) => {
+          const contents = await readFile(join(flagsDir, file), 'utf8')
+          const values = contents?.split('\n')
+          return [parse(file).name, values]
+        }),
+    )
+
+    for (const [flag, values] of flagsToInsert) {
+      for (const value of values) {
+        argv.push(`--${flag}`)
+        if (value) argv.push(value)
+      }
+    }
+  }
+
+  return argv
+}
+
+export default hook

--- a/test/parser/fixtures/preparse-plugin/tsconfig.json
+++ b/test/parser/fixtures/preparse-plugin/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDirs": ["./src"]
+  },
+  "include": ["./src/**/*"]
+}

--- a/test/parser/preparse.test.ts
+++ b/test/parser/preparse.test.ts
@@ -1,0 +1,192 @@
+import {expect} from 'chai'
+import fs from 'node:fs/promises'
+import {join, resolve} from 'node:path'
+import {SinonSandbox, createSandbox, match} from 'sinon'
+
+import {Config, Interfaces} from '../../src'
+import Test from './fixtures/preparse-plugin/src/commands/test'
+
+type TestReturnType = {
+  args: Interfaces.InferredArgs<typeof Test.args>
+  flags: Interfaces.InferredFlags<typeof Test.flags>
+}
+
+describe('preparse hook', () => {
+  let sandbox: SinonSandbox
+  let config: Config
+
+  beforeEach(async () => {
+    sandbox = createSandbox()
+    config = await Config.load(resolve(__dirname, join('fixtures', 'preparse-plugin')))
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('implement groupAliases', () => {
+    it('should add flags that belong to alias group', async () => {
+      const {flags} = await config.runCommand<TestReturnType>('test', ['--combo'])
+      expect(flags).to.deep.equal({
+        burger: 'double',
+        combo: true,
+        fries: true,
+        shake: 'strawberry',
+        sauce: ['ketchup'],
+      })
+    })
+
+    it('should add flags that belong to alias group when using short char', async () => {
+      const {flags} = await config.runCommand<TestReturnType>('test', ['-c'])
+      expect(flags).to.deep.equal({
+        burger: 'double',
+        combo: true,
+        fries: true,
+        shake: 'strawberry',
+        sauce: ['ketchup'],
+      })
+    })
+
+    it('should add flags that belong to alias group and allow flag overrides', async () => {
+      const {flags} = await config.runCommand<TestReturnType>('test', ['--combo', '--shake', 'vanilla'])
+      expect(flags).to.deep.equal({
+        burger: 'double',
+        combo: true,
+        fries: true,
+        shake: 'vanilla',
+        sauce: ['ketchup'],
+      })
+    })
+
+    it('should add flags that belong to alias group and allow short char flag overrides', async () => {
+      const {flags} = await config.runCommand<TestReturnType>('test', ['--combo', '-s', 'vanilla'])
+      expect(flags).to.deep.equal({
+        burger: 'double',
+        combo: true,
+        fries: true,
+        shake: 'vanilla',
+        sauce: ['ketchup'],
+      })
+    })
+  })
+
+  describe('implement --flags-dir', () => {
+    const flagsDir = resolve(__dirname, 'fixtures', 'flags')
+
+    function makeStubs(files: Array<{name: string; content: string}>) {
+      // @ts-expect-error because sinon wants it to be a Dirent[] but node returns string[]
+      sandbox.stub(fs, 'readdir').resolves(files.map(({name}) => name))
+
+      for (const {name, content} of files) {
+        sandbox.stub(fs, 'readFile').withArgs(match(name)).resolves(content)
+      }
+    }
+
+    describe('boolean flags', () => {
+      it('should add boolean from directory', async () => {
+        makeStubs([{name: 'fries', content: ''}])
+        const {flags} = await config.runCommand<TestReturnType>('test', ['--flags-dir', flagsDir])
+        expect(flags).to.deep.equal({
+          burger: 'double',
+          fries: true,
+          'flags-dir': flagsDir,
+          sauce: ['ketchup'],
+        })
+      })
+
+      it('should add boolean from directory and allow flag overrides', async () => {
+        makeStubs([{name: 'fries', content: ''}])
+        const {flags} = await config.runCommand<TestReturnType>('test', ['--flags-dir', flagsDir, '--no-fries'])
+        expect(flags).to.deep.equal({
+          burger: 'double',
+          fries: false,
+          'flags-dir': flagsDir,
+          sauce: ['ketchup'],
+        })
+      })
+
+      it('should add boolean from directory and allow short char flag overrides', async () => {
+        makeStubs([{name: 'fries', content: 'false'}])
+        const {flags} = await config.runCommand<TestReturnType>('test', ['--flags-dir', flagsDir, '-f'])
+        expect(flags).to.deep.equal({
+          burger: 'double',
+          fries: true,
+          'flags-dir': flagsDir,
+          sauce: ['ketchup'],
+        })
+      })
+    })
+
+    describe('string flags', () => {
+      it('should add string from directory', async () => {
+        makeStubs([{name: 'shake', content: 'vanilla'}])
+        const {flags} = await config.runCommand<TestReturnType>('test', ['--flags-dir', flagsDir])
+        expect(flags).to.deep.equal({
+          burger: 'double',
+          shake: 'vanilla',
+          'flags-dir': flagsDir,
+          sauce: ['ketchup'],
+        })
+      })
+
+      it('should add string from directory to override default', async () => {
+        makeStubs([{name: 'burger', content: 'single'}])
+        const {flags} = await config.runCommand<TestReturnType>('test', ['--flags-dir', flagsDir])
+        expect(flags).to.deep.equal({
+          burger: 'single',
+          'flags-dir': flagsDir,
+          sauce: ['ketchup'],
+        })
+      })
+
+      it('should add string from directory and allow flag overrides', async () => {
+        makeStubs([{name: 'shake', content: 'vanilla'}])
+        const {flags} = await config.runCommand<TestReturnType>('test', [
+          '--flags-dir',
+          flagsDir,
+          '--shake',
+          'chocolate',
+        ])
+        expect(flags).to.deep.equal({
+          burger: 'double',
+          shake: 'chocolate',
+          'flags-dir': flagsDir,
+          sauce: ['ketchup'],
+        })
+      })
+
+      it('should add string from directory and allow short char flag overrides', async () => {
+        makeStubs([{name: 'shake', content: 'vanilla'}])
+        const {flags} = await config.runCommand<TestReturnType>('test', ['--flags-dir', flagsDir, '-s', 'chocolate'])
+        expect(flags).to.deep.equal({
+          burger: 'double',
+          shake: 'chocolate',
+          'flags-dir': flagsDir,
+          sauce: ['ketchup'],
+        })
+      })
+    })
+
+    describe('multiple flags', () => {
+      it('should combine values from directory with values from argv', async () => {
+        makeStubs([{name: 'sauce', content: 'bbq'}])
+        const {flags} = await config.runCommand<TestReturnType>('test', ['--flags-dir', flagsDir, '--sauce', 'mustard'])
+        expect(flags).to.deep.equal({
+          burger: 'double',
+          sauce: ['mustard', 'bbq'],
+          'flags-dir': flagsDir,
+        })
+      })
+
+      it('should add multiple from directory', async () => {
+        makeStubs([{name: 'sauce', content: 'ketchup\nmustard\nbbq'}])
+        const {flags} = await config.runCommand<TestReturnType>('test', ['--flags-dir', flagsDir, '--sauce', 'mayo'])
+        expect(flags).to.deep.equal({
+          burger: 'double',
+          sauce: ['mayo', 'ketchup', 'mustard', 'bbq'],
+          'flags-dir': flagsDir,
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Adds `preparse` hook that allows people to manipulate the `argv` before it gets processed by `Parser`

- Only the root plugin can use the `preparse` hook - all others will be ignored. This is mainly to avoid conflicts between different hooks and to prevent untrusted plugins from maliciously manipulating the `argv`
- See `test/parser/fixtures/preparse-plugin` for an example implementation

Fixes #962 
@W-15213828@