### PR TITLE
fix: ensure string is passed to process.emitWarning

### DIFF
--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -343,7 +343,7 @@ export class Plugin implements IPlugin {
   }
 
   private addErrorScope(err: any, scope?: string) {
-    err.name = `${err.name} Plugin: ${this.name}`
+    err.name = err.name ?? inspect(err).trim()
     err.detail = compact([
       err.detail,
       `module: ${this._base}`,
@@ -431,6 +431,7 @@ export class Plugin implements IPlugin {
 
   private warn(err: CLIError | Error | string, scope?: string): void {
     if (typeof err === 'string') err = new Error(err)
-    process.emitWarning(this.addErrorScope(err, scope))
+    const warning = this.addErrorScope(err, scope)
+    process.emitWarning(warning.name, warning)
   }
 }

--- a/src/config/ts-path.ts
+++ b/src/config/ts-path.ts
@@ -1,3 +1,4 @@
+import {access} from 'node:fs/promises'
 import {join, relative as pathRelative, sep} from 'node:path'
 import * as TSNode from 'ts-node'
 
@@ -212,8 +213,23 @@ async function determinePath(root: string, orig: string): Promise<string> {
 
   debug(`lib dir: ${lib}`)
   debug(`src dir: ${src}`)
-  debug(`src commands dir: ${out}`)
-  if (existsSync(out) || existsSync(out + '.ts')) {
+  debug(`src directory to find: ${out}`)
+
+  if (existsSync(out)) {
+    debug(`Found source directory for ${orig} at ${out}`)
+    return out
+  }
+
+  const sourceFiles = await Promise.all([
+    access(`${out}.ts`)
+      .then(() => `${out}.ts`)
+      .catch(() => false),
+    access(`${out}.tsx`)
+      .then(() => `${out}.tsx`)
+      .catch(() => false),
+  ])
+
+  if (sourceFiles.some(Boolean)) {
     debug(`Found source file for ${orig} at ${out}`)
     return out
   }


### PR DESCRIPTION
Errors emitted from ts-node are objects with [custom inspections](https://nodejs.org/api/util.html#custom-inspection-functions-on-objects) instead of errors or strings, which causes this error when emitting the warning:

```
TypeError: The "warning" argument must be of type string or an instance of Error. Received src/commands/task/get.tsx(2,9): error TS6133: 'Box' is declared but its value is never read.

    at process.emitWarning (node:internal/process/warning:176:11)
    at Plugin.warn (/Users/mdonnalley/repos/oclif/core/lib/config/plugin.js:372:17)
    at /Users/mdonnalley/repos/oclif/core/lib/config/plugin.js:276:30
    at async Promise.all (index 19)
    at async Plugin._manifest (/Users/mdonnalley/repos/oclif/core/lib/config/plugin.js:257:24)
    at async Plugin.load (/Users/mdonnalley/repos/oclif/core/lib/config/plugin.js:208:25)
    at async PluginLoader.loadRoot (/Users/mdonnalley/repos/oclif/core/lib/config/plugin-loader.js:67:13)
    at async Config.load (/Users/mdonnalley/repos/oclif/core/lib/config/config.js:266:27)
    at async Function.load (/Users/mdonnalley/repos/oclif/core/lib/config/config.js:156:9)
    at async run (/Users/mdonnalley/repos/oclif/core/lib/main.js:59:20)
```

Calling `util.inspect` on the object gives a string that we can pass in, so the warning now looks like:

```
(node:92535) Warning: src/commands/task/get.tsx(2,9): error TS6133: 'Box' is declared but its value is never read.
module: @oclif/core@3.19.6
task: findCommand (task:get)
plugin: multiple-repo-manager
root: /Users/mdonnalley/repos/mdonnalley/multiple-repo-manager
See more details with DEBUG=*
Error: command task:get:done not found
    at Config.runCommand (/Users/mdonnalley/repos/oclif/core/lib/config/config.js:402:19)
    at async run (/Users/mdonnalley/repos/oclif/core/lib/main.js:92:16)
    at async main (file:///Users/mdonnalley/repos/mdonnalley/multiple-repo-manager/bin/dev.js:5:3)
    at async file:///Users/mdonnalley/repos/mdonnalley/multiple-repo-manager/bin/dev.js:8:1
```