### PR TITLE
fix: allow .tsx and .jsx help class files

### DIFF
--- a/src/help/index.ts
+++ b/src/help/index.ts
@@ -4,6 +4,7 @@ import stripAnsi from 'strip-ansi'
 import {colorize} from '../cli-ux/theme'
 import write from '../cli-ux/write'
 import {Command} from '../command'
+import {tsPath} from '../config/ts-path'
 import {error} from '../errors/error'
 import * as Interfaces from '../interfaces'
 import {load} from '../module-loader'
@@ -394,8 +395,9 @@ export async function loadHelpClass(config: Interfaces.Config): Promise<HelpBase
 
   if (configuredClass) {
     try {
-      const exported = (await load(config, configuredClass)) as HelpBaseDerived
-      return extractClass(exported) as HelpBaseDerived
+      const path = (await tsPath(config.root, configuredClass)) ?? configuredClass
+      const exported = await load<HelpBaseDerived>(config, path)
+      return extractClass(exported)
     } catch (error: any) {
       throw new Error(
         `Unable to load configured help class "${configuredClass}", failed with message:\n${error.message}`,

--- a/src/module-loader.ts
+++ b/src/module-loader.ts
@@ -13,8 +13,8 @@ const getPackageType = require('get-package-type')
 /**
  * Defines file extension resolution when source files do not have an extension.
  */
-// eslint-disable-next-line camelcase
-const s_EXTENSIONS: string[] = ['.ts', '.js', '.mjs', '.cjs', '.mts', '.cts']
+
+const SUPPORTED_EXTENSIONS: string[] = ['.ts', '.js', '.mjs', '.cjs', '.mts', '.cts', '.tsx', '.jsx']
 
 const isPlugin = (config: IConfig | IPlugin): config is IPlugin => (<IPlugin>config).type !== undefined
 
@@ -215,8 +215,7 @@ async function resolvePath(config: IConfig | IPlugin, modulePath: string): Promi
  * @returns {string | null} Modified file path including extension or null if file is not found.
  */
 function findFile(filePath: string): null | string {
-  // eslint-disable-next-line camelcase
-  for (const extension of s_EXTENSIONS) {
+  for (const extension of SUPPORTED_EXTENSIONS) {
     const testPath = `${filePath}${extension}`
 
     if (existsSync(testPath)) {


### PR DESCRIPTION
Allow custom help classes to be exported from `.tsx` or `.jsx` files