### PR TITLE
fix: do not throw an error if a flag with allowStdin='only' is immediately followed by another flag (#1046)

### DIFF
--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -173,7 +173,7 @@ export class Parser<
         this.currentFlag = flag
         let input = isLong || arg.length < 3 ? this.argv.shift() : arg.slice(arg[2] === '=' ? 3 : 2)
 
-        if (flag.allowStdin === 'only' && input !== '-' && input !== undefined) {
+        if (flag.allowStdin === 'only' && input !== '-' && input !== undefined && !this.findFlag(input).name) {
           throw new CLIError(
             `Flag --${name} can only be read from stdin. The value must be "-" or not provided at all.`,
           )

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -1956,4 +1956,17 @@ describe('allowStdin', () => {
       }
     }
   })
+
+  it('should read stdin as input for flag when allowStdin is "only" and no value is given, and a second flag is used after', async () => {
+    sandbox.stub(parser, 'readStdin').returns(stdinPromise)
+    const out = await parse(['--myflag', '--myflag2'], {
+      flags: {
+        myflag: Flags.string({allowStdin: 'only'}),
+        myflag2: Flags.boolean(),
+      },
+    })
+
+    expect(out.flags.myflag).to.equals(stdinValue)
+    expect(out.raw[0].input).to.equal('x')
+  })
 })


### PR DESCRIPTION
Merges #1046 

Fixes https://github.com/forcedotcom/cli/issues/2811