### PR TITLE
fix: new "dont check npm" option for plugin-update 

### DIFF
--- a/src/interfaces/pjson.ts
+++ b/src/interfaces/pjson.ts
@@ -149,7 +149,7 @@ export namespace PJSON {
           debounce?: number
           rollout?: number
         }
-        disableNpmLookup: boolean
+        disableNpmLookup?: boolean
         node: {
           targets?: string[]
           version?: string

--- a/src/interfaces/pjson.ts
+++ b/src/interfaces/pjson.ts
@@ -149,6 +149,7 @@ export namespace PJSON {
           debounce?: number
           rollout?: number
         }
+        disableNpmLookup: boolean
         node: {
           targets?: string[]
           version?: string


### PR DESCRIPTION
this PR adds a type in order for [the other PR](https://github.com/oclif/plugin-update/pull/807) on oclif/plugin-update to work