### PR TITLE
fix: restore baseFlags support

### DIFF
--- a/src/interfaces/flags.ts
+++ b/src/interfaces/flags.ts
@@ -4,7 +4,7 @@ import {FlagInput} from './parser'
  * Infer the flags that are returned by Command.parse. This is useful for when you want to assign the flags as a class property.
  *
  * @example
- * export type StatusFlags = Interfaces.InferredFlags<typeof Status.flags>
+ * export type StatusFlags = Interfaces.InferredFlags<typeof Status.flags && typeof Status.baseFlags>
  *
  * export abstract class BaseCommand extends Command {
  *   static enableJsonFlag = true
@@ -18,7 +18,6 @@ import {FlagInput} from './parser'
  *
  * export default class Status extends BaseCommand {
  *   static flags = {
- *    ...BaseCommand.flags,
  *     force: Flags.boolean({char: 'f', description: 'a flag'}),
  *   }
  *

--- a/src/interfaces/hooks.ts
+++ b/src/interfaces/hooks.ts
@@ -51,7 +51,7 @@ export interface Hooks {
   preparse: {
     options: {
       argv: string[]
-      options: Input<OutputFlags<any>, OutputFlags<any>>
+      options: Input<OutputFlags<any>, OutputFlags<any>, OutputFlags<any>>
     }
     return: string[]
   }

--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -416,8 +416,9 @@ export type FlagDefinition<
 
 export type Flag<T> = BooleanFlag<T> | OptionFlag<T>
 
-export type Input<TFlags extends FlagOutput, AFlags extends ArgOutput> = {
+export type Input<TFlags extends FlagOutput, BFlags extends FlagOutput, AFlags extends ArgOutput> = {
   flags?: FlagInput<TFlags>
+  baseFlags?: FlagInput<BFlags>
   enableJsonFlag?: true | false
   args?: ArgInput<AFlags>
   strict?: boolean | undefined

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -4,10 +4,11 @@ import {validate} from './validate'
 
 export {flagUsages} from './help'
 
-export async function parse<TFlags extends OutputFlags<any>, TArgs extends OutputArgs<any>>(
-  argv: string[],
-  options: Input<TFlags, TArgs>,
-): Promise<ParserOutput<TFlags, TArgs>> {
+export async function parse<
+  TFlags extends OutputFlags<any>,
+  BFlags extends OutputFlags<any>,
+  TArgs extends OutputArgs<any>,
+>(argv: string[], options: Input<TFlags, BFlags, TArgs>): Promise<ParserOutput<TFlags, BFlags, TArgs>> {
   const input = {
     '--': options['--'],
     args: (options.args ?? {}) as ArgInput<any>,
@@ -19,5 +20,5 @@ export async function parse<TFlags extends OutputFlags<any>, TArgs extends Outpu
   const parser = new Parser(input)
   const output = await parser.parse()
   await validate({input, output})
-  return output as ParserOutput<TFlags, TArgs>
+  return output as ParserOutput<TFlags, BFlags, TArgs>
 }

--- a/src/util/aggregate-flags.ts
+++ b/src/util/aggregate-flags.ts
@@ -6,9 +6,11 @@ const json = boolean({
   helpGroup: 'GLOBAL',
 })
 
-export function aggregateFlags<F extends FlagOutput>(
+export function aggregateFlags<F extends FlagOutput, B extends FlagOutput>(
   flags: FlagInput<F> | undefined,
+  baseFlags: FlagInput<B> | undefined,
   enableJsonFlag: boolean | undefined,
 ): FlagInput<F> {
-  return (enableJsonFlag ? {json, ...flags} : flags) as FlagInput<F>
+  const combinedFlags = {...baseFlags, ...flags}
+  return (enableJsonFlag ? {json, ...combinedFlags} : combinedFlags) as FlagInput<F>
 }


### PR DESCRIPTION
Restore support for `baseFlags`