### PR TITLE
fix: only replace command id in usage if it's at beginning of string

### DIFF
--- a/src/help/command.ts
+++ b/src/help/command.ts
@@ -349,7 +349,11 @@ export class CommandHelp extends HelpFormatter {
 
         const commandDescription = colorize(
           this.config?.theme?.sectionDescription,
-          u.replace('<%= command.id %>', '').replace(standardId, '').replace(configuredId, '').trim(),
+          u
+            .replace('<%= command.id %>', '')
+            .replace(new RegExp(`^${standardId}`), '')
+            .replace(new RegExp(`^${configuredId}`), '')
+            .trim(),
         )
 
         const line = `${dollarSign} ${bin} ${command} ${commandDescription}`.trim()

--- a/test/help/format-command.test.ts
+++ b/test/help/format-command.test.ts
@@ -577,6 +577,53 @@ ARGUMENTS
       expect(output).to.equal(`USAGE
   $ oclif apps:create`)
     })
+
+    it('should output usage with hardcoded command', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          usage: ['apps:create'],
+        }),
+      )
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
+  $ oclif apps:create`)
+    })
+
+    it('should output default usage for single letter command', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'a',
+          flags: {
+            'a-flag': flags.string({char: 'a', options: ['a', 'aa', 'aaa']}),
+          },
+        }),
+      )
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
+  $ oclif a [-a a|aa|aaa]
+
+FLAGS
+  -a, --a-flag=<option>  <options: a|aa|aaa>`)
+    })
+
+    it('should output usage for single letter command', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'a',
+          flags: {
+            'a-flag': flags.string({char: 'a', options: ['a', 'aa', 'aaa']}),
+          },
+          usage: 'a [-a a|aa|aaa]',
+        }),
+      )
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
+  $ oclif a [-a a|aa|aaa]
+
+FLAGS
+  -a, --a-flag=<option>  <options: a|aa|aaa>`)
+    })
   })
 
   describe('examples', () => {


### PR DESCRIPTION
Only replace command id in usage if it's at the beginning of the string. This solves problem where the command id is present elsewhere in the string (e.g. if it's a single letter command id)

Note: external unit tests failing because oclif plugins are now using v4

Fixes #1089
@W-15903264@