### PR TITLE
feat: added option to specify example flag value in docopts

### DIFF
--- a/src/help/command.ts
+++ b/src/help/command.ts
@@ -166,12 +166,11 @@ export class CommandHelp extends HelpFormatter {
     }
 
     if (flag.type === 'option') {
-      let value = flag.helpValue || (this.opts.showFlagNameInTitle ? flag.name : '<value>')
-      if (!flag.helpValue && flag.options) {
-        value = showOptions || this.opts.showFlagOptionsInTitle ? `${flag.options.join('|')}` : '<option>'
-      }
-
-      if (flag.multiple) value += '...'
+      let value = DocOpts.formatUsageType(
+        flag,
+        this.opts.showFlagNameInTitle ?? false,
+        this.opts.showFlagOptionsInTitle ?? showOptions,
+      )
       if (!value.includes('|')) value = chalk.underline(value)
       label += `=${value}`
     }

--- a/src/help/docopts.ts
+++ b/src/help/docopts.ts
@@ -96,7 +96,7 @@ export class DocOpts {
         ...this.flagList.map((flag) => {
           const name = flag.char ? `-${flag.char}` : `--${flag.name}`
           if (flag.type === 'boolean') return name
-          return `${name}=<value>`
+          return `${name}=${this.formatUsageType(flag)}`
         }),
       )
     }
@@ -135,6 +135,19 @@ export class DocOpts {
     delete this.flagMap[flagName]
   }
 
+  private formatUsageType(flag: Command.Flag.Any) {
+    if (flag.type !== 'option') return
+
+    let usageValues: string[]
+    if (flag.usageType === undefined) {
+      usageValues = ['<value>']
+    } else {
+      usageValues = typeof flag.usageType === 'string' ? [flag.usageType] : flag.usageType
+    }
+
+    return usageValues.map((v) => `${v}${flag.multiple ? '...' : ''}`).join(' ')
+  }
+
   private generateElements(elementMap: {[index: string]: string} = {}, flagGroups: Command.Flag.Any[] = []): string[] {
     const elementStrs = []
     for (const flag of flagGroups) {
@@ -142,7 +155,7 @@ export class DocOpts {
       // not all flags have short names
       const flagName = flag.char ? `-${flag.char}` : `--${flag.name}`
       if (flag.type === 'option') {
-        type = flag.options ? ` ${flag.options.join('|')}` : ' <value>'
+        type = flag.options ? ` ${flag.options.join('|')}` : ` ${this.formatUsageType(flag)}`
       }
 
       const element = `${flagName}${type}`

--- a/src/help/docopts.ts
+++ b/src/help/docopts.ts
@@ -72,6 +72,26 @@ export class DocOpts {
       })
   }
 
+  public static formatUsageType(flag: Command.Flag.Any, showFlagName: boolean, showOptions: boolean): string {
+    if (flag.type !== 'option') return ''
+
+    let helpValues: string[]
+    if (flag.helpValue) {
+      // if there is a given helpValue, use it
+      helpValues = typeof flag.helpValue === 'string' ? [flag.helpValue] : flag.helpValue
+    } else if (flag.options) {
+      // if there are options, show them if wanted
+      helpValues = [showOptions ? flag.options.join('|') : '<option>']
+    } else if (showFlagName) {
+      helpValues = [flag.name]
+    } else {
+      // default to <value>
+      helpValues = ['<value>']
+    }
+
+    return helpValues.map((v) => `${v}${flag.multiple ? '...' : ''}`).join(' ')
+  }
+
   public static generate(cmd: Command.Loadable): string {
     return new DocOpts(cmd).toString()
   }
@@ -96,7 +116,7 @@ export class DocOpts {
         ...this.flagList.map((flag) => {
           const name = flag.char ? `-${flag.char}` : `--${flag.name}`
           if (flag.type === 'boolean') return name
-          return `${name}=${this.formatUsageType(flag)}`
+          return `${name}=${DocOpts.formatUsageType(flag, false, true)}`
         }),
       )
     }
@@ -135,19 +155,6 @@ export class DocOpts {
     delete this.flagMap[flagName]
   }
 
-  private formatUsageType(flag: Command.Flag.Any) {
-    if (flag.type !== 'option') return
-
-    let usageValues: string[]
-    if (flag.usageType === undefined) {
-      usageValues = ['<value>']
-    } else {
-      usageValues = typeof flag.usageType === 'string' ? [flag.usageType] : flag.usageType
-    }
-
-    return usageValues.map((v) => `${v}${flag.multiple ? '...' : ''}`).join(' ')
-  }
-
   private generateElements(elementMap: {[index: string]: string} = {}, flagGroups: Command.Flag.Any[] = []): string[] {
     const elementStrs = []
     for (const flag of flagGroups) {
@@ -155,7 +162,7 @@ export class DocOpts {
       // not all flags have short names
       const flagName = flag.char ? `-${flag.char}` : `--${flag.name}`
       if (flag.type === 'option') {
-        type = flag.options ? ` ${flag.options.join('|')}` : ` ${this.formatUsageType(flag)}`
+        type = ` ${DocOpts.formatUsageType(flag, false, true)}`
       }
 
       const element = `${flagName}${type}`

--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -207,6 +207,16 @@ export type BooleanFlagProps = FlagProps & {
 export type OptionFlagProps = FlagProps & {
   type: 'option'
   helpValue?: string
+  /**
+   * Specify types to show in help usage strings
+   *
+   * Ex: `usageType: ['input-json', 'input-xml']` gets
+   *
+   * `mycommand -i <input-json>... <input-xml>...`
+   *
+   * if `multiple` is also `true`
+   */
+  usageType?: string | string[]
   options?: readonly string[]
   multiple?: boolean
   /**
@@ -295,10 +305,10 @@ type FlagReturnType<T, R extends ReturnTypeSwitches> = R['requiredOrDefaulted'] 
       : T[]
     : T
   : R['multiple'] extends true
-  ? [T] extends [Array<unknown>]
-    ? T | undefined
-    : T[] | undefined
-  : T | undefined
+    ? [T] extends [Array<unknown>]
+      ? T | undefined
+      : T[] | undefined
+    : T | undefined
 
 /**
  * FlagDefinition types a function that takes `options` and returns an OptionFlag<T>.

--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -206,17 +206,7 @@ export type BooleanFlagProps = FlagProps & {
 
 export type OptionFlagProps = FlagProps & {
   type: 'option'
-  helpValue?: string
-  /**
-   * Specify types to show in help usage strings
-   *
-   * Ex: `usageType: ['input-json', 'input-xml']` gets
-   *
-   * `mycommand -i <input-json>... <input-xml>...`
-   *
-   * if `multiple` is also `true`
-   */
-  usageType?: string | string[]
+  helpValue?: string | string[]
   options?: readonly string[]
   multiple?: boolean
   /**

--- a/test/help/docopts.test.ts
+++ b/test/help/docopts.test.ts
@@ -265,4 +265,40 @@ describe('doc opts', () => {
     } as any)
     expect(usage).to.contain(' (-s <value> -f <value>)')
   })
+
+  it('is uses usageTypes as expected', () => {
+    const usage = DocOpts.generate({
+      flags: {
+        testFlag: Flags.url({
+          name: 'testFlag',
+          description: 'test',
+          char: 's',
+          required: true,
+          usageType: ['<test1>', '<test2>'],
+          multiple: true,
+        }),
+        testFlag2: Flags.string({
+          name: 'testFlag2',
+          description: 'test',
+          char: 'f',
+          required: true,
+          usageType: '<test3>',
+        }),
+        testFlag3: Flags.string({
+          name: 'testFlag3',
+          description: 'test',
+          char: 'g',
+          required: true,
+          multiple: true,
+        }),
+        testFlag4: Flags.string({
+          name: 'testFlag4',
+          description: 'test',
+          char: 'p',
+          required: true,
+        }),
+      },
+    } as any)
+    expect(usage).to.contain('-s <test1>... <test2>... -f <test3> -g <value>... -p <value>')
+  })
 })

--- a/test/help/docopts.test.ts
+++ b/test/help/docopts.test.ts
@@ -266,7 +266,7 @@ describe('doc opts', () => {
     expect(usage).to.contain(' (-s <value> -f <value>)')
   })
 
-  it('is uses usageTypes as expected', () => {
+  it('is uses helpValues as expected', () => {
     const usage = DocOpts.generate({
       flags: {
         testFlag: Flags.url({
@@ -274,7 +274,7 @@ describe('doc opts', () => {
           description: 'test',
           char: 's',
           required: true,
-          usageType: ['<test1>', '<test2>'],
+          helpValue: ['<test1>', '<test2>'],
           multiple: true,
         }),
         testFlag2: Flags.string({
@@ -282,7 +282,7 @@ describe('doc opts', () => {
           description: 'test',
           char: 'f',
           required: true,
-          usageType: '<test3>',
+          helpValue: '<test3>',
         }),
         testFlag3: Flags.string({
           name: 'testFlag3',
@@ -296,9 +296,10 @@ describe('doc opts', () => {
           description: 'test',
           char: 'p',
           required: true,
+          options: ['option1', 'option2'],
         }),
       },
     } as any)
-    expect(usage).to.contain('-s <test1>... <test2>... -f <test3> -g <value>... -p <value>')
+    expect(usage).to.contain('-s <test1>... <test2>... -f <test3> -g <value>... -p option1|option2')
   })
 })

--- a/test/help/format-command.test.ts
+++ b/test/help/format-command.test.ts
@@ -360,6 +360,27 @@ FLAGS
   --myenum=a|b|c`)
     })
 
+    it('should output helpValue in usage string', async () => {
+      const cmd = await makeLoadable(
+        makeCommandClass({
+          id: 'apps:create',
+          flags: {
+            files: flags.string({
+              helpValue: ['<input-json>', '<input-xml>'],
+              multiple: true,
+            }),
+          },
+        }),
+      )
+
+      const output = help.formatCommand(cmd)
+      expect(output).to.equal(`USAGE
+  $ oclif apps:create [--files <input-json>... <input-xml>...]
+
+FLAGS
+  --files=<input-json>... <input-xml>...`)
+    })
+
     it('should output with default flag options', async () => {
       const cmd = await makeLoadable(
         makeCommandClass({


### PR DESCRIPTION
Feature add for #1088 
- Made changes to the docopts formatter
- Wrote a test for the docopts changes

There is the option to include multiple example flags such that the usage string can format to something like 
`mycli -i <input-json>... <input-xml>...`