### PR TITLE
fix: add export for parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "./hooks": "./lib/interfaces/hooks.js",
     "./interfaces": "./lib/interfaces/index.js",
     "./logger": "./lib/logger.js",
+    "./parser": "./lib/parser/index.js",
     "./performance": "./lib/performance.js",
     "./run": "./lib/main.js",
     "./settings": "./lib/settings.js",


### PR DESCRIPTION
Adds export for parser

```typescript
const { parse } = await import('@oclif/core/parser');
```

Closes https://github.com/oclif/core/discussions/1097

