### PR TITLE
fix: export parser related types

### DIFF
--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -7,7 +7,21 @@ export type {HelpOptions} from './help'
 export type {Hook, Hooks} from './hooks'
 export type {Logger} from './logger'
 export type {Manifest} from './manifest'
-export type {Arg, BooleanFlag, CustomOptions, Deprecation, Flag, FlagDefinition, OptionFlag} from './parser'
+export type {
+  Arg,
+  ArgInput,
+  BooleanFlag,
+  CustomOptions,
+  Deprecation,
+  Flag,
+  FlagDefinition,
+  FlagInput,
+  Input,
+  OptionFlag,
+  OutputArgs,
+  OutputFlags,
+  ParserOutput,
+} from './parser'
 export type {LinkedPlugin, OclifConfiguration, PJSON, S3, S3Templates, UserPJSON, UserPlugin} from './pjson'
 export type {Options, Plugin, PluginOptions} from './plugin'
 export type {S3Manifest} from './s3-manifest'

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,6 +1,9 @@
-import {ArgInput, FlagInput, Input, OutputArgs, OutputFlags, ParserOutput} from '../interfaces/parser'
+import type {ArgInput, FlagInput, Input, OutputArgs, OutputFlags, ParserOutput} from '../interfaces/parser'
+
 import {Parser} from './parse'
 import {validate} from './validate'
+
+export type {ArgInput, FlagInput, Input, OutputArgs, OutputFlags, ParserOutput} from '../interfaces/parser'
 
 export {flagUsages} from './help'
 


### PR DESCRIPTION
Exports the following under `Interfaces` and `@oclif/core/parser`

`ArgInput`
`FlagInput`
`Input`
`OutputArgs`
`OutputFlags`
`ParserOutput`