### PR TITLE
fix: use lilconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "ansis": "^3.1.1",
     "clean-stack": "^3.0.1",
     "cli-spinners": "^2.9.2",
-    "cosmiconfig": "^9.0.0",
     "debug": "^4.3.5",
     "ejs": "^3.1.10",
     "get-package-type": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "globby": "^11.1.0",
     "indent-string": "^4.0.0",
     "is-wsl": "^2.2.0",
+    "lilconfig": "^3.1.2",
     "minimatch": "^9.0.4",
     "string-width": "^4.2.3",
     "supports-color": "^8",

--- a/src/util/read-pjson.ts
+++ b/src/util/read-pjson.ts
@@ -1,4 +1,4 @@
-import {cosmiconfig} from 'cosmiconfig'
+import {lilconfig} from 'lilconfig'
 import {join} from 'node:path'
 
 import {PJSON} from '../interfaces'
@@ -8,7 +8,7 @@ import {readJson} from './fs'
 const debug = makeDebug('read-pjson')
 
 /**
- * Read the package.json file from a given path and add the oclif config (found by cosmiconfig) if it exists.
+ * Read the package.json file from a given path and add the oclif config (found by lilconfig) if it exists.
  *
  * We can assume that the package.json file exists because the plugin root has already been loaded at this point.
  */
@@ -21,14 +21,14 @@ export async function readPjson(path: string): Promise<PJSON> {
 
   const pjson = await readJson<PJSON>(pjsonPath)
 
-  // don't bother with cosmiconfig if the plugin's package.json already has an oclif config
+  // don't bother with lilconfig if the plugin's package.json already has an oclif config
   if (pjson.oclif) {
     debug(`found oclif config in ${pjsonPath}`)
     return pjson
   }
 
   debug(`searching for oclif config in ${path}`)
-  const explorer = cosmiconfig('oclif', {
+  const explorer = lilconfig('oclif', {
     /**
      * Remove the following from the defaults:
      * - package.json
@@ -37,18 +37,14 @@ export async function readPjson(path: string): Promise<PJSON> {
     searchPlaces: [
       '.oclifrc',
       '.oclifrc.json',
-      '.oclifrc.yaml',
-      '.oclifrc.yml',
       '.oclifrc.js',
-      '.oclifrc.ts',
       '.oclifrc.mjs',
       '.oclifrc.cjs',
       'oclif.config.js',
-      'oclif.config.ts',
       'oclif.config.mjs',
       'oclif.config.cjs',
     ],
-    searchStrategy: 'none',
+    stopDir: path,
   })
   const result = await explorer.search(path)
   if (!result?.config) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4360,7 +4360,7 @@ libnpmversion@^5.0.1:
     proc-log "^3.0.0"
     semver "^7.3.7"
 
-lilconfig@~3.1.1:
+lilconfig@^3.1.2, lilconfig@~3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.2.tgz#e4a7c3cb549e3a606c8dcc32e5ae1005e62c05cb"
   integrity sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==
@@ -6272,16 +6272,7 @@ string-argv@~0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6351,14 +6342,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6885,7 +6869,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -6898,15 +6882,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Use lilconfig instead of cosmicconfig for reading rc files so that typescript doesn't get shipped

### Testing

- link this branch to sf repo
- move `oclif` config from package.json to rc file (see below) (package.json should **not** contain an oclif section)
- run `bin/run.js` version (if the command succeeds you can assume that the config worked)
- note: only have a single rc file at a time, otherwise lilconfig will only use the first one it finds

#### RC Files

**.oclifrc**
```json
{
  "bin": "sf",
  // etc...
}
```

**.oclifrc.json**

```json
{
  "bin": "sf",
  // etc...
}
```

**.oclifrc.js**

```js
export default {
  bin: 'sf',
  // etc...
}
```

**.oclifrc.mjs**

```js
export default {
  bin: 'sf',
  // etc...
}
```

**.oclifrc.cjs**

```js
module.exports = {
  bin: 'sf',
  // etc...
}
```

**oclif.config.js**

```js
export default {
  bin: 'sf',
  // etc...
}
```

**oclif.config.mjs**

```js
export default {
  bin: 'sf',
  // etc...
}
```

**oclif.config.cjs**

```js
module.exports = {
  bin: 'sf',
  // etc...
}
```

