### PR TITLE
fix: ignore cache when reading user pjson

### DIFF
--- a/src/config/plugin-loader.ts
+++ b/src/config/plugin-loader.ts
@@ -208,7 +208,8 @@ export default class PluginLoader {
       try {
         const userPJSONPath = join(opts.dataDir, 'package.json')
         debug('reading user plugins pjson %s', userPJSONPath)
-        const pjson = await readJson<PJSON>(userPJSONPath)
+        // ignore cache because the file might have changed within the same process (e.g. during a JIT plugin install)
+        const pjson = await readJson<PJSON>(userPJSONPath, true)
         if (!pjson.oclif) pjson.oclif = {schema: 1}
         if (!pjson.oclif.plugins) pjson.oclif.plugins = []
         await this.loadPlugins(

--- a/src/config/plugin-loader.ts
+++ b/src/config/plugin-loader.ts
@@ -209,7 +209,7 @@ export default class PluginLoader {
         const userPJSONPath = join(opts.dataDir, 'package.json')
         debug('reading user plugins pjson %s', userPJSONPath)
         // ignore cache because the file might have changed within the same process (e.g. during a JIT plugin install)
-        const pjson = await readJson<PJSON>(userPJSONPath, true)
+        const pjson = await readJson<PJSON>(userPJSONPath, false)
         if (!pjson.oclif) pjson.oclif = {schema: 1}
         if (!pjson.oclif.plugins) pjson.oclif.plugins = []
         await this.loadPlugins(

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -63,11 +63,11 @@ const cache = new ProdOnlyCache()
  * Will throw an error if the file does not exist.
  *
  * @param path file path of JSON file
- * @param ignoreCache if true, ignore cache and read file from disk
+ * @param useCache if false, ignore cache and read file from disk
  * @returns <T>
  */
-export async function readJson<T = unknown>(path: string, ignoreCache = false): Promise<T> {
-  if (!ignoreCache && cache.has(path)) {
+export async function readJson<T = unknown>(path: string, useCache = true): Promise<T> {
+  if (useCache && cache.has(path)) {
     return JSON.parse(cache.get(path)!) as T
   }
 
@@ -82,12 +82,12 @@ export async function readJson<T = unknown>(path: string, ignoreCache = false): 
  * Will return undefined if the file does not exist.
  *
  * @param path file path of JSON file
- * @param ignoreCache if true, ignore cache and read file from disk
+ * @param useCache if false, ignore cache and read file from disk
  * @returns <T> or undefined
  */
-export async function safeReadJson<T>(path: string, ignoreCache = false): Promise<T | undefined> {
+export async function safeReadJson<T>(path: string, useCache = true): Promise<T | undefined> {
   try {
-    return await readJson<T>(path, ignoreCache)
+    return await readJson<T>(path, useCache)
   } catch {}
 }
 


### PR DESCRIPTION
Ignore the `ProdOnlyCache` when reading the user pjson because it could have been modified by a JIT install

Fixes issue with first execution of a JIT plugin failing with this error:

```
sf dev generate library                               
@salesforce/cli: Installing plugin dev@2.3.2... installed v2.3.2
 ›   ModuleLoadError: [MODULE_NOT_FOUND] import() failed to load /Users/peter.hale/.npm-global/lib/node_modules/@salesforce/cli/lib/commands/dev/generate/library.js: Cannot find module 
 ›   '/Users/peter.hale/.npm-global/lib/node_modules/@salesforce/cli/lib/commands/dev/generate/library.js' imported from /Users/peter.hale/.npm-global/lib/node_modules/@salesforce/cli/node_modules/@oclif/core/lib/module-loader.js
 ›   Code: MODULE_NOT_FOUND
```

**Testing**

1. Checkout branch, `yarn build`
2. cd to sf repo
3. `yarn link @oclif/core`
4. `yarn oclif manifest`
5. `bin/run.js dev generate plugin`

It should JIT install plugin-dev and successfully run the `dev generate plugin` command