### PR TITLE
fix: use colorize to ensure proper TTY detection

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -1,4 +1,3 @@
-import ansis from 'ansis'
 import {fileURLToPath} from 'node:url'
 import {inspect} from 'node:util'
 
@@ -196,7 +195,7 @@ export abstract class Command {
     } else {
       if (!err.message) throw err
       try {
-        ux.action.stop(ansis.bold.red('!'))
+        ux.action.stop(ux.colorize('bold', ux.colorize('red', '!')))
       } catch {}
 
       throw err

--- a/src/errors/errors/cli.ts
+++ b/src/errors/errors/cli.ts
@@ -1,4 +1,3 @@
-import ansis from 'ansis'
 import cs from 'clean-stack'
 import indent from 'indent-string'
 import wrap from 'wrap-ansi'
@@ -7,6 +6,7 @@ import Cache from '../../cache'
 import {OclifError, PrettyPrintableError} from '../../interfaces/errors'
 import {errtermwidth} from '../../screen'
 import {settings} from '../../settings'
+import {colorize} from '../../ux/theme'
 
 /**
  * properties specific to internal oclif error handling
@@ -39,7 +39,7 @@ export class CLIError extends Error implements OclifError {
 
   get bang(): string | undefined {
     try {
-      return ansis.red(process.platform === 'win32' ? '»' : '›')
+      return colorize('red', process.platform === 'win32' ? '»' : '›')
     } catch {}
   }
 
@@ -74,7 +74,7 @@ export namespace CLIError {
 
     get bang(): string | undefined {
       try {
-        return ansis.yellow(process.platform === 'win32' ? '»' : '›')
+        return colorize('yellow', process.platform === 'win32' ? '»' : '›')
       } catch {}
     }
   }

--- a/src/help/command.ts
+++ b/src/help/command.ts
@@ -170,7 +170,7 @@ export class CommandHelp extends HelpFormatter {
         this.opts.showFlagNameInTitle ?? false,
         this.opts.showFlagOptionsInTitle ?? showOptions,
       )
-      if (!value.includes('|')) value = ansis.underline(value)
+      if (!value.includes('|')) value = colorize('underline', value)
       label += `=${value}`
     }
 

--- a/src/help/formatter.ts
+++ b/src/help/formatter.ts
@@ -181,7 +181,7 @@ export class HelpFormatter {
     }
 
     const output = [
-      colorize(this.config?.theme?.sectionHeader, ansis.bold(header)),
+      colorize(this.config?.theme?.sectionHeader, colorize('bold', header)),
       colorize(
         this.config?.theme?.sectionDescription,
         this.indent(

--- a/src/parser/errors.ts
+++ b/src/parser/errors.ts
@@ -1,10 +1,9 @@
-import ansis from 'ansis'
-
 import Cache from '../cache'
 import {CLIError} from '../errors'
 import {Arg, ArgInput, CLIParseErrorOptions, OptionFlag} from '../interfaces/parser'
 import {uniq} from '../util/util'
 import renderList from '../ux/list'
+import {colorize} from '../ux/theme'
 
 export {CLIError} from '../errors'
 
@@ -124,7 +123,7 @@ export class FailedFlagValidationError extends CLIParseError {
     const reasons = failed.map((r) => r.reason)
     const deduped = uniq(reasons)
     const errString = deduped.length === 1 ? 'error' : 'errors'
-    const message = `The following ${errString} occurred:\n  ${ansis.dim(deduped.join('\n  '))}`
+    const message = `The following ${errString} occurred:\n  ${colorize('dim', deduped.join('\n  '))}`
     super({exit: Cache.getInstance().get('exitCodes')?.failedFlagValidation ?? exit, message, parse})
   }
 }

--- a/src/parser/help.ts
+++ b/src/parser/help.ts
@@ -1,7 +1,6 @@
-import ansis from 'ansis'
-
 import {Flag, FlagUsageOptions} from '../interfaces/parser'
 import {sortBy} from '../util/util'
+import {colorize} from '../ux'
 
 export function flagUsage(flag: Flag<any>, options: FlagUsageOptions = {}): [string, string | undefined] {
   const label = []
@@ -17,7 +16,7 @@ export function flagUsage(flag: Flag<any>, options: FlagUsageOptions = {}): [str
 
   let description: string | undefined = flag.summary || flag.description || ''
   if (options.displayRequired && flag.required) description = `(required) ${description}`
-  description = description ? ansis.dim(description) : undefined
+  description = description ? colorize('dim', description) : undefined
 
   return [` ${label.join(',').trim()}${usage}`, description] as [string, string | undefined]
 }


### PR DESCRIPTION
Always use `ux.colorize` to ensure consistent TTY detection

@W-16198524@
https://github.com/forcedotcom/cli/issues/2951