### PR TITLE
fix: ignore escaped delimiters

### DIFF
--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -646,6 +646,14 @@ See more help with --help`)
             expect(error.message).to.include('Expected --foo=b c to be one of: a a, b b')
           }
         })
+        it('does not split on escaped delimiter', async () => {
+          const out = await parse(['--foo', 'a\\,b,c'], {
+            flags: {
+              foo: Flags.string({multiple: true, delimiter: ','}),
+            },
+          })
+          expect(out.flags).to.deep.include({foo: ['a,b', 'c']})
+        })
       })
     })
 

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -519,6 +519,27 @@ See more help with --help`)
         })
         expect(out.flags).to.deep.include({foo: ['a', 'b']})
       })
+      it('parses single flag starting with with \\ escape char', async () => {
+        const out = await parse(['--foo', '\\file:foo'], {
+          flags: {
+            foo: Flags.custom({multiple: true})(),
+          },
+        })
+        expect(out.flags).to.deep.include({foo: ['\\file:foo']})
+      })
+      it('parses multiple space-delimited flags ending with with \\ escape char', async () => {
+        const out = await parse(['--foo', 'c:\\', 'd:\\'], {
+          flags: {foo: Flags.string({multiple: true})},
+        })
+        expect(out.flags).to.deep.include({foo: ['c:\\', 'd:\\']})
+      })
+      it('parses multiple space-delimited flags ending with with \\ escape char', async () => {
+        const out = await parse(['--foo', 'c:\\', 'd:\\'], {
+          flags: {foo: Flags.string({multiple: true})},
+        })
+        expect(out.flags).to.deep.include({foo: ['c:\\', 'd:\\']})
+      })
+
       it('allowed options on multiple', async () => {
         const out = await parse(['--foo', 'a', '--foo=b'], {
           flags: {
@@ -646,6 +667,14 @@ See more help with --help`)
             expect(error.message).to.include('Expected --foo=b c to be one of: a a, b b')
           }
         })
+        it('retains escape char without delimiter', async () => {
+          const out = await parse(['--foo', 'a\\'], {
+            flags: {
+              foo: Flags.string({multiple: true, delimiter: ','}),
+            },
+          })
+          expect(out.flags).to.deep.include({foo: ['a\\']})
+        })
         it('does not split on escaped delimiter', async () => {
           const out = await parse(['--foo', 'a\\,b,c'], {
             flags: {
@@ -653,6 +682,25 @@ See more help with --help`)
             },
           })
           expect(out.flags).to.deep.include({foo: ['a,b', 'c']})
+        })
+        it('escapes with multiple invocation', async () => {
+          const out = await parse(['--foo', 'a\\,b', '--foo', 'b'], {
+            flags: {
+              foo: Flags.string({multiple: true, delimiter: ','}),
+            },
+          })
+          expect(out.flags).to.deep.include({foo: ['a,b', 'b']})
+        })
+
+        it('comma-escaped stringified json', async () => {
+          const val = '{"a":"b"\\,"c":"d"}'
+          const expected = '{"a":"b","c":"d"}'
+          const out = await parse(['--foo', val], {
+            flags: {
+              foo: Flags.string({multiple: true, delimiter: ','}),
+            },
+          })
+          expect(out.flags).to.deep.include({foo: [expected]})
         })
       })
     })
@@ -717,7 +765,6 @@ See more help with --help`)
             strict: false,
             '--': false,
           })
-          console.log(out)
           expect(out.argv).to.deep.equal(['foo', 'bar', '--', '--myflag'])
           expect(out.args).to.deep.equal({argOne: 'foo'})
         })

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -527,6 +527,12 @@ See more help with --help`)
         })
         expect(out.flags).to.deep.include({foo: ['\\file:foo']})
       })
+      it('parses multiple space-delimited flags', async () => {
+        const out = await parse(['--foo', 'a', 'b', 'c'], {
+          flags: {foo: Flags.string({multiple: true})},
+        })
+        expect(out.flags).to.deep.include({foo: ['a', 'b', 'c']})
+      })
       it('parses multiple space-delimited flags ending with with \\ escape char', async () => {
         const out = await parse(['--foo', 'c:\\', 'd:\\'], {
           flags: {foo: Flags.string({multiple: true})},


### PR DESCRIPTION
Ignore escaped delimiters when splitting input string for flags with `delimiter` and `multiple`

**Before**
```
my-cli --flag one,two,three` => {flag: ['one', 'two', 'three']}
```

**After**
```
my-cli --flag one\,two,three` => {flag: ['one,two', 'three']}
```

This is useful when you have flag values that contain the delimiter but shouldn't be split.

_Depending on you shell, you might need to double escape to get the desired effect._

@W-16343745@
https://github.com/forcedotcom/cli/issues/2928