### PR TITLE
fix: use file url to import tsx at runtime

### DIFF
--- a/src/config/ts-path.ts
+++ b/src/config/ts-path.ts
@@ -89,6 +89,7 @@ async function registerTsx(root: string, moduleType: 'commonjs' | 'module' | und
     const {href} = pathToFileURL(tsxPath)
     debug('tsx href:', href)
     const {register} = await import(href)
+    debug('Successfully imported tsx')
     register()
     REGISTERED.add(root)
   } catch (error) {
@@ -108,6 +109,7 @@ async function registerTSNode(root: string, tsconfig: TSConfig): Promise<void> {
 
   try {
     tsNode = require(tsNodePath)
+    debug('Successfully required ts-node')
   } catch (error) {
     debug(`Could not find ts-node at ${tsNodePath}. Skipping ts-node registration for ${root}.`)
     debug(error)

--- a/src/config/ts-path.ts
+++ b/src/config/ts-path.ts
@@ -1,5 +1,6 @@
 import {access} from 'node:fs/promises'
 import {join, relative as pathRelative, sep} from 'node:path'
+import {pathToFileURL} from 'node:url'
 import * as TSNode from 'ts-node'
 
 import Cache from '../cache'
@@ -85,11 +86,14 @@ async function registerTsx(root: string, moduleType: 'commonjs' | 'module' | und
     if (!tsxPath) return
     debug('registering tsx at', root)
     debug('tsx path:', tsxPath)
-    const {register} = await import(tsxPath)
+    const {href} = pathToFileURL(tsxPath)
+    debug('tsx href:', href)
+    const {register} = await import(href)
     register()
     REGISTERED.add(root)
-  } catch {
+  } catch (error) {
     debug(`Could not find tsx. Skipping tsx registration for ${root}.`)
+    debug(error)
   }
 }
 
@@ -104,8 +108,9 @@ async function registerTSNode(root: string, tsconfig: TSConfig): Promise<void> {
 
   try {
     tsNode = require(tsNodePath)
-  } catch {
+  } catch (error) {
     debug(`Could not find ts-node at ${tsNodePath}. Skipping ts-node registration for ${root}.`)
+    debug(error)
     memoizedWarn(
       `Could not find ts-node at ${tsNodePath}. Please ensure that ts-node is a devDependency. Falling back to compiled source.`,
     )


### PR DESCRIPTION
- Use file url to import tsx at runtime
- debug errors caused by importing ts-node and/or tsx

**QA**
- create new ESM cli on windows: `oclif generate my-cli --yes`
- install `tsx` globally: `npm install -g tsx`
- add `tsx` to my-cli: `npm install --save-dev tsx`
- remove ts-node from my-cli: `npm uninstall ts-node`
- update shebang in dev.js to `#!/usr/bin/env -S npx tsx --no-warnings`
- update dev.cmd to use `npx tsx` instead of `node --loader ts-node/esm --no-warnings=ExperimentalWarning`
- delete the `dist` directory
- set `DEBUG=*`
- run `bin\dev.cmd hello world`

The command should successfully run and the logs should indicate that tsx did not fail to be imported:

```
  oclif:config:ts-path registering tsx at C:\Users\username\code\tsx-bug-esm +7ms
  oclif:config:ts-path tsx path: C:\Users\username\code\tsx-bug-esm\node_modules\tsx\dist\esm\api\index.cjs +8ms
  oclif:config:ts-path Successfully imported tsx +0ms
```

It's probably worth repeating these steps on mac or linux too

Fixes #1170 
@W-16530475@