### PR TITLE
fix: handle large throughput writes

### DIFF
--- a/src/ux/write.ts
+++ b/src/ux/write.ts
@@ -1,25 +1,24 @@
 import {format} from 'node:util'
-
 export const stdout = (str?: string | string[] | undefined, ...args: string[]): void => {
   if (!str && args) {
-    process.stdout.write(format(...args) + '\n')
+    console.log(format(...args))
   } else if (!str) {
-    process.stdout.write('\n')
+    console.log()
   } else if (typeof str === 'string') {
-    process.stdout.write((str && format(str, ...args)) + '\n')
+    console.log(format(str, ...args))
   } else {
-    process.stdout.write(format(...str, ...args) + '\n')
+    console.log(format(...str, ...args))
   }
 }
 
 export const stderr = (str?: string | string[] | undefined, ...args: string[]): void => {
   if (!str && args) {
-    process.stderr.write(format(...args) + '\n')
+    console.error(format(...args))
   } else if (!str) {
-    process.stderr.write('\n')
+    console.error()
   } else if (typeof str === 'string') {
-    process.stderr.write((str && format(str, ...args)) + '\n')
+    console.error(format(str, ...args))
   } else {
-    process.stderr.write(format(...str, ...args) + '\n')
+    console.error(format(...str, ...args))
   }
 }

--- a/test/ux/write.test.ts
+++ b/test/ux/write.test.ts
@@ -34,6 +34,22 @@ describe('write', () => {
       const {stdout} = await captureOutput(async () => writeStdout())
       expect(stdout).to.equal('\n')
     })
+
+    it('should not lose data', async () => {
+      const lines = Array.from(
+        {length: 100_000},
+        (_, i) =>
+          `Line ${i} Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer convallis fringilla sollicitudin. Nunc scelerisque neque non ipsum accumsan commodo. In et porttitor eros, ut vestibulum magna. Morbi felis diam, pharetra eu dui non, sollicitudin feugiat nisi. Aliquam cursus malesuada risus, vel luctus leo ornare sed. Morbi condimentum odio id ex facilisis bibendum. Nullam consectetur consectetur viverra. Donec nec ante dui. Integer lacinia facilisis urna vitae feugiat.`,
+      )
+
+      const {stdout} = await captureOutput(async () => {
+        for (const line of lines) {
+          writeStdout(line)
+        }
+      })
+
+      expect(stdout).to.equal(lines.join('\n') + '\n')
+    })
   })
 
   describe('stderr', () => {
@@ -65,6 +81,22 @@ describe('write', () => {
     it('should write a new line with no input', async () => {
       const {stderr} = await captureOutput(async () => writeStderr())
       expect(stderr).to.equal('\n')
+    })
+
+    it('should not lose data', async () => {
+      const lines = Array.from(
+        {length: 100_000},
+        (_, i) =>
+          `Line ${i} Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer convallis fringilla sollicitudin. Nunc scelerisque neque non ipsum accumsan commodo. In et porttitor eros, ut vestibulum magna. Morbi felis diam, pharetra eu dui non, sollicitudin feugiat nisi. Aliquam cursus malesuada risus, vel luctus leo ornare sed. Morbi condimentum odio id ex facilisis bibendum. Nullam consectetur consectetur viverra. Donec nec ante dui. Integer lacinia facilisis urna vitae feugiat.`,
+      )
+
+      const {stderr} = await captureOutput(async () => {
+        for (const line of lines) {
+          writeStderr(line)
+        }
+      })
+
+      expect(stderr).to.equal(lines.join('\n') + '\n')
     })
   })
 })


### PR DESCRIPTION
Use `console.log` and `console.error` instead of `process.stdout.write` and `process.stderr.write`, to avoid losing information from back pressure on the streams

To replicate:

```js
// write.js

import {stdout} from './src/ux/write.js'
const lines = Array.from(
  {length: 100},
  (_, i) =>
    `Line ${i} Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer convallis fringilla sollicitudin. Nunc scelerisque neque non ipsum accumsan commodo. In et porttitor eros, ut vestibulum magna. Morbi felis diam, pharetra eu dui non, sollicitudin feugiat nisi. Aliquam cursus malesuada risus, vel luctus leo ornare sed. Morbi condimentum odio id ex facilisis bibendum. Nullam consectetur consectetur viverra. Donec nec ante dui. Integer lacinia facilisis urna vitae feugiat.`,
)

for (const line of lines) {
  stdout(line)
}
```

```
bun write.js
```

**NOTE** that the issue can only be replicated with bun - not node


Fixes #1177 

@W-16645420@