### PR TITLE
fix: warn about node version mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "is-wsl": "^2.2.0",
     "lilconfig": "^3.1.2",
     "minimatch": "^9.0.5",
+    "semver": "^7.6.3",
     "string-width": "^4.2.3",
     "supports-color": "^8",
     "widest-line": "^3.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import {isTruthy} from './util/util'
 function checkCWD() {
   try {
     process.cwd()
@@ -8,7 +9,25 @@ function checkCWD() {
   }
 }
 
+function checkNodeVersion() {
+  if (process.env.OCLIF_DISABLE_ENGINE_WARNING && isTruthy(process.env.OCLIF_DISABLE_ENGINE_WARNING)) return
+  try {
+    const semver = require('semver')
+    const path = require('node:path')
+    const root = path.join(__dirname, '..')
+    const pjson = require(path.join(root, 'package.json'))
+    if (!semver.satisfies(process.versions.node, pjson.engines.node)) {
+      process.emitWarning(
+        `Node version must be ${pjson.engines.node} to use this CLI. Current node version: ${process.versions.node}`,
+      )
+    }
+  } catch {
+    // ignore
+  }
+}
+
 checkCWD()
+checkNodeVersion()
 
 export * as Args from './args'
 export {Command} from './command'


### PR DESCRIPTION
Emit process warning when oclif/core's node engine property is not satisfied

```
❯ sf version
(node:16992) Warning: Node version must be >=22.0.0 to use this CLI. Current node version: 20.13.1
(Use `node --trace-warnings ...` to show where the warning was created)
@salesforce/cli/2.60.8 darwin-arm64 node-v20.13.1
```

@W-16795546@
Fixes https://github.com/oclif/core/issues/1197