### PR TITLE
fix: deprecated aliases bug

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -283,7 +283,8 @@ export abstract class Command {
     // Since config.runHook will only run the hook for the root plugin, hookResult.successes will always have a length of 0 or 1
     // But to be extra safe, we find the result that matches the root plugin.
     const argvToParse = hookResult.successes?.length
-      ? hookResult.successes.find((s) => s.plugin.root === Cache.getInstance().get('rootPlugin')?.root)?.result ?? argv
+      ? (hookResult.successes.find((s) => s.plugin.root === Cache.getInstance().get('rootPlugin')?.root)?.result ??
+        argv)
       : argv
     this.argv = [...argvToParse]
     const results = await Parser.parse<F, B, A>(argvToParse, opts)
@@ -336,7 +337,7 @@ export abstract class Command {
         )
         if (aliases.length === 0) return
 
-        const foundAliases = aliases.filter((alias) => this.argv.some((a) => a.startsWith(alias)))
+        const foundAliases = aliases.filter((alias) => this.argv.includes(alias))
         for (const alias of foundAliases) {
           let preferredUsage = `--${flagDef?.name}`
           if (flagDef?.char) {

--- a/test/command/command.test.ts
+++ b/test/command/command.test.ts
@@ -95,7 +95,7 @@ describe('command', () => {
     class CMD extends Command {
       static flags = {
         name: Flags.string({
-          aliases: ['username', 'target-user', 'u'],
+          aliases: ['username', 'target-user', 'u', 'nam'],
           deprecateAliases: true,
           char: 'o',
         }),
@@ -135,6 +135,11 @@ describe('command', () => {
 
     it('shows no warning when proper flag name with a value that matches a short char flag alias', async () => {
       const {stderr} = await captureOutput(async () => CMD.run(['--name', 'u']))
+      expect(stderr).to.be.empty
+    })
+
+    it('shows no warning when using flag with deprecated alias that starts with the actual flag', async () => {
+      const {stderr} = await captureOutput(async () => CMD.run(['--name', 'astro']))
       expect(stderr).to.be.empty
     })
   })


### PR DESCRIPTION
Fix bug with `deprecateAliases` warning showing when flag name starts with deprecated alias.

**QA**
- `oclif generate my-cli`
- add this flag definition to `src/commands/hello/index.ts`
```
    'foo-bar': Flags.boolean({
      summary: 'summary',
      deprecateAliases: true,
      aliases: ['foo']
    }),
```
- checkout this branch and run `yarn build`
- `yarn link @oclif/core` in `my-cli` directory
- `bin/dev.js hello oclif --from me --foo-bar` should **not** emit warning
- `bin/dev.js hello oclif --from me --foo` should emit warning

Fixes #1204 
@W-16866149@