### PR TITLE
fix: use topic separator for deprecated alias warnings in `help`

### DIFF
--- a/src/help/index.ts
+++ b/src/help/index.ts
@@ -201,7 +201,8 @@ export class Help extends HelpBase {
 
     if (command.deprecateAliases && command.aliases.includes(name)) {
       const actualCmd = this.config.commands.find((c) => c.aliases.includes(name))
-      const opts = {...command.deprecationOptions, ...(actualCmd ? {to: actualCmd.id} : {})}
+      const actualCmdName = actualCmd ? toConfiguredId(actualCmd.id, this.config) : ''
+      const opts = {...command.deprecationOptions, ...(actualCmd ? {to: actualCmdName} : {})}
       this.log(`${formatCommandDeprecationWarning(toConfiguredId(name, this.config), opts)}\n`)
     }
 


### PR DESCRIPTION
Makes the warning for deprecated aliases here: https://github.com/oclif/core/blob/cc8366a70310682a389f3ffdebd202b1860e09d8/src/help/index.ts#L202-L206
use the topic separator by passing `actualCmd.id` into `toConfiguredIds` and using *that* result for the `to` in the `Deprecation` type parameter of `formatCommandDeprecationWarning` as done here: https://github.com/oclif/core/blob/66604a36aea80be30457cf19bdfb8891d24cc4c9/src/command.ts#L311-L315