### PR TITLE
fix: add respectNoCacheDefault to help options

### DIFF
--- a/src/help/command.ts
+++ b/src/help/command.ts
@@ -188,7 +188,8 @@ export class CommandHelp extends HelpFormatter {
       if (noChar) left = left.replace('    ', '')
 
       let right = flag.summary || flag.description || ''
-      if (flag.type === 'option' && flag.default) {
+      const canBeCached = !(this.opts.respectNoCacheDefault === true && flag.noCacheDefault === true)
+      if (flag.type === 'option' && flag.default && canBeCached) {
         right = `${colorize(this.config?.theme?.flagDefaultValue, `[default: ${flag.default}]`)} ${right}`
       }
 

--- a/src/interfaces/help.ts
+++ b/src/interfaces/help.ts
@@ -25,6 +25,10 @@ export interface HelpOptions {
   hideCommandSummaryInDescription?: boolean
   maxWidth: number
   /**
+   * Respect the `noCacheDefault` property on flags. Defaults to false.
+   */
+  respectNoCacheDefault?: boolean
+  /**
    * Only show the help for the specified sections. Defaults to all sections.
    */
   sections?: string[]


### PR DESCRIPTION
Add `respectNoCacheDefault` option to help so that `oclif readme` can ignore any defaults for flags that have `noCacheDefault` property

@W-16883857@
https://github.com/forcedotcom/cli/issues/3041 

