### PR TITLE
W-17672123 fix: add env var to disable link warning

### DIFF
--- a/src/config/ts-path.ts
+++ b/src/config/ts-path.ts
@@ -9,7 +9,7 @@ import {Plugin, TSConfig} from '../interfaces'
 import {settings} from '../settings'
 import {existsSync} from '../util/fs'
 import {readTSConfig} from '../util/read-tsconfig'
-import {isProd} from '../util/util'
+import {isProd, isTruthy} from '../util/util'
 import {makeDebug} from './util'
 
 const debug = makeDebug('ts-path')
@@ -314,7 +314,12 @@ export async function tsPath(
     debug(
       `Skipping typescript path lookup for ${root} because it's an ESM module (NODE_ENV: ${process.env.NODE_ENV}, root plugin module type: ${rootPlugin?.moduleType})`,
     )
-    if (plugin?.type === 'link')
+
+    const warningIsDisabled =
+      process.env.OCLIF_DISABLE_LINKED_ESM_WARNING && isTruthy(process.env.OCLIF_DISABLE_LINKED_ESM_WARNING)
+
+    // Only warn if the plugin is linked AND the warning is not disabled
+    if (plugin?.type === 'link' && !warningIsDisabled)
       memoizedWarn(
         `${plugin?.name} is a linked ESM module and cannot be auto-transpiled. Existing compiled source will be used instead.`,
       )


### PR DESCRIPTION
Add `OCLIF_DISABLE_LINKED_ESM_WARNING` env var to disable warning that displays when using a linked ESM plugin

**With** env var
```
~/repos/trailheadapps/dreamhouse-lwc on  main [?] via ⬢ v20.15.0
❯ OCLIF_DISABLE_LINKED_ESM_WARNING=true sf agent create --name My_Agent --job-spec config/agentSpec.json

 ──────────── Creating My_Agent Agent ────────────

 ✔ Parsing config/agentSpec.json 186ms
 ✔ Generating GenAiPlanner metadata 189ms
 ✔ Creating agent in org 4.78s
 ✔ Retrieving agent metadata 2.81s

 Elapsed Time: 8.10s

Successfully created My_Agent in test-dpowgjdizsnx@example.com.
Use sf agent open --agent My_Agent to view the agent in the browser.
```

**Without** env var
```
~/repos/trailheadapps/dreamhouse-lwc on  main [?] via ⬢ v20.15.0 took 10.7s
❯ sf agent create --name My_Agent --job-spec config/agentSpec.json
 ›   Warning: @salesforce/plugin-agent is a linked ESM module and cannot be auto-transpiled. Existing compiled source will be used
 ›   instead.

 ──────────── Creating My_Agent Agent ────────────

 ✔ Parsing config/agentSpec.json 191ms
 ✔ Generating GenAiPlanner metadata 191ms
 ✔ Creating agent in org 4.76s
 ✔ Retrieving agent metadata 2.72s

 Elapsed Time: 8.01s

Successfully created My_Agent in test-dpowgjdizsnx@example.com.
Use sf agent open --agent My_Agent to view the agent in the browser.
```