### PR TITLE
fix: typo in ux module README

### DIFF
--- a/src/ux/README.md
+++ b/src/ux/README.md
@@ -104,7 +104,7 @@ import {stderr} from '@oclif/core/ux'
 stderr('hello %s', 'world')
 ```
 
-### `stderr`
+### `stdout`
 
 Log a formatted string to stdout
 


### PR DESCRIPTION
This PR fixes a typo in `ux/README.md`: the section header `stderr` is duplicated, the second should be `stdout`.