### PR TITLE
feat: add finally hook

### DIFF
--- a/src/interfaces/hooks.ts
+++ b/src/interfaces/hooks.ts
@@ -26,6 +26,10 @@ export interface Hooks {
     options: {argv?: string[]; id: string}
     return: unknown
   }
+  finally: {
+    options: {argv: string[]; id: string}
+    return: void
+  }
   init: {
     options: {argv: string[]; id: string | undefined}
     return: void
@@ -75,6 +79,10 @@ export type Hook<T extends keyof P, P extends Hooks = Hooks> = (
 ) => Promise<P[T]['return']>
 
 export namespace Hook {
+  /**
+   * Runs at the end of the CLI lifecycle - regardless of success or failure.
+   */
+  export type Finally = Hook<'finally'>
   /**
    * Runs when the CLI is initialized before a command is executed.
    */


### PR DESCRIPTION
Add `finally` hook that will run at the end of every command execution - regardless of success or failure.

## Usage
```ts
// src/hooks/finally.ts
import {Hook} from '@oclif/core'

const hook: Hook.Finally = async function (opts) {
  this.log(`I finally finished running ${opts.id} with args: ${opts.argv.join(' ')}`)
}

export default hook
```

## Issues
Closes #1275 
Closes #1263 
Closes #1264
@W-17482601@