### PR TITLE
feat: export validate from the Parse module

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -6,6 +6,7 @@ import {validate} from './validate'
 export type {ArgInput, FlagInput, Input, OutputArgs, OutputFlags, ParserOutput} from '../interfaces/parser'
 
 export {flagUsages} from './help'
+export {validate} from './validate'
 
 export async function parse<
   TFlags extends OutputFlags<any>,


### PR DESCRIPTION
The oclif project I am working on includes a features that allow one to orchestrate the execution of a pipeline of Oclif commands. Since it supplies JSON to each command with args and flags it is wasteful to put the json back into a command line and then parse the flags and args out again. That said, we do want to validate the args and flags but now that Oclif better controls is exports, we do not have access to the needed validate function. This PR restores access to the validate call so that we do not have have to copy and reproduce all of that code in our project. We have been working off a private fork for this one change but are nearing release and would like to make things right ahead of that.

Thanks for your consideration!