### PR TITLE
feat: add generic for extending `Hooks` on `config.runHook`

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -494,12 +494,12 @@ export class Config implements IConfig {
     return result
   }
 
-  public async runHook<T extends keyof Hooks>(
+  public async runHook<T extends keyof Hooks, P extends Hooks = Hooks>(
     event: T,
-    opts: Hooks[T]['options'],
+    opts: P[T]['options'],
     timeout?: number,
     captureErrors?: boolean,
-  ): Promise<Hook.Result<Hooks[T]['return']>> {
+  ): Promise<Hook.Result<P[T]['return']>> {
     const marker = Performance.mark(OCLIF_MARKER_OWNER, `config.runHook#${event}`)
     debug('start %s hook', event)
     const search = (m: any): Hook<T> => {
@@ -522,10 +522,10 @@ export class Config implements IConfig {
       })
     }
 
-    const final = {
+    const final: Hook.Result<P[T]['return']> = {
       failures: [],
       successes: [],
-    } as Hook.Result<Hooks[T]['return']>
+    }
 
     const plugins = ROOT_ONLY_HOOKS.has(event) ? [this.rootPlugin] : [...this.plugins.values()]
     const promises = plugins.map(async (p) => {


### PR DESCRIPTION
The `Hook` interface has a handy generic so we can have additional type safety around hook inputs/outputs:

https://github.com/oclif/core/blob/e60d769054b36009743bf39408fe30303e122464/src/interfaces/hooks.ts#L76

This PR extends that logic over to the `config.runHook` method.