### PR TITLE
feat: migrate from globby to tinyglobby

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "debug": "^4.4.0",
     "ejs": "^3.1.10",
     "get-package-type": "^0.1.0",
-    "globby": "^11.1.0",
     "indent-string": "^4.0.0",
     "is-wsl": "^2.2.0",
     "lilconfig": "^3.1.3",
@@ -20,6 +19,7 @@
     "semver": "^7.6.3",
     "string-width": "^4.2.3",
     "supports-color": "^8",
+    "tinyglobby": "^0.2.13",
     "widest-line": "^3.1.0",
     "wordwrap": "^1.0.0",
     "wrap-ansi": "^7.0.0"
@@ -130,5 +130,6 @@
     "test:perf": "ts-node test/perf/parser.perf.ts",
     "test": "nyc mocha --forbid-only \"test/**/*.test.ts\" --parallel"
   },
-  "types": "lib/index.d.ts"
+  "types": "lib/index.d.ts",
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/config/plugin.ts
+++ b/src/config/plugin.ts
@@ -1,6 +1,6 @@
-import globby from 'globby'
 import {join, parse, relative, sep} from 'node:path'
 import {inspect} from 'node:util'
+import {glob} from 'tinyglobby'
 
 import Cache from '../cache'
 import {Command} from '../command'
@@ -368,7 +368,7 @@ export class Plugin implements IPlugin {
     if (!commandsDir) return []
 
     this._debug(`loading IDs from ${commandsDir}`)
-    const files = await globby(this.commandDiscoveryOpts?.globPatterns ?? GLOB_PATTERNS, {cwd: commandsDir})
+    const files = await glob(this.commandDiscoveryOpts?.globPatterns ?? GLOB_PATTERNS, {cwd: commandsDir})
     return processCommandIds(files)
   }
 

--- a/test/config/fixtures/esm/package.json
+++ b/test/config/fixtures/esm/package.json
@@ -17,6 +17,6 @@
     }
   },
   "devDependencies": {
-    "globby": "^8.0.1"
+    "tinyglobby": "^0.2.13"
   }
 }

--- a/test/config/fixtures/mixed-cjs-esm/package.json
+++ b/test/config/fixtures/mixed-cjs-esm/package.json
@@ -16,6 +16,6 @@
     }
   },
   "devDependencies": {
-    "globby": "^8.0.1"
+    "tinyglobby": "^0.2.13"
   }
 }

--- a/test/config/fixtures/mixed-esm-cjs/package.json
+++ b/test/config/fixtures/mixed-esm-cjs/package.json
@@ -17,6 +17,6 @@
     }
   },
   "devDependencies": {
-    "globby": "^8.0.1"
+    "tinyglobby": "^0.2.13"
   }
 }

--- a/test/config/fixtures/typescript/package.json
+++ b/test/config/fixtures/typescript/package.json
@@ -15,7 +15,7 @@
     }
   },
   "devDependencies": {
-    "globby": "^8.0.1",
+    "tinyglobby": "^0.2.13",
     "ts-node": "^6.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3566,6 +3566,11 @@ fdir@^6.4.3:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.3.tgz#011cdacf837eca9b811c89dbb902df714273db72"
   integrity sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==
 
+fdir@^6.4.4:
+  version "6.4.4"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.4.tgz#1cfcf86f875a883e19a8fab53622cfe992e8d2f9"
+  integrity sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==
+
 file-entry-cache@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-8.0.0.tgz#7787bddcf1131bffb92636c69457bbc0edd6d81f"
@@ -7409,6 +7414,14 @@ tinyglobby@^0.2.12:
   integrity sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==
   dependencies:
     fdir "^6.4.3"
+    picomatch "^4.0.2"
+
+tinyglobby@^0.2.13:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.13.tgz#a0e46515ce6cbcd65331537e57484af5a7b2ff7e"
+  integrity sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==
+  dependencies:
+    fdir "^6.4.4"
     picomatch "^4.0.2"
 
 to-fast-properties@^2.0.0:


### PR DESCRIPTION
Hi!
## What is this PR 
This PR migrates `globby` to [tinyglobby](https://github.com/SuperchupuDev/tinyglobby), and reducing the total oclif/core dependencies by ~21 (see graphs below)

Tinyglobby has ~52M downloads a month, used by many other large consumers (vite, pnpm, etc) - it has only 2 subdependencies, compared to globby's [23](https://npmgraph.js.org/?q=globby@14.1.0) and fast-glob's [17](https://npmgraph.js.org/?q=fast-glob@3.3.3).

This will reduce the total #deps down by 21 🥳 It's also in-line with the [e18e ecosystem cleanup initative](https://e18e.dev/)

## Context 
I was looking at oclif's dependency graph https://npmgraph.js.org/?q=%40oclif%2Fcore#select=exact%3Aglobby%4011.1.0 and noticed that globby was being pulled in with it's 23 dependencies, for just one line of usage! 
![{31359E48-E228-46DB-BC50-F4CEDD908AFD}](https://github.com/user-attachments/assets/19df72d5-a1cf-40ba-8505-6307b81f7e2d)

Compared to after this PR
![{DE8FF868-D9E3-421A-81FB-FF3642D3F5B9}](https://github.com/user-attachments/assets/f6e8a535-d923-4538-9359-56a515ae71c3)

### Aside
I've read https://github.com/oclif/core/blob/main/CONRTIBUTING.md#dependencies and its note around Dependencies - but as this was not a dependency **bump**, i have raised this :) 

Thank you for your time!
