### PR TITLE
fix: do not list hidden arguments in usage

### DIFF
--- a/src/help/docopts.ts
+++ b/src/help/docopts.ts
@@ -101,9 +101,11 @@ export class DocOpts {
       // If strict is false, add ellipsis to indicate that the argument takes multiple values
       const suffix = this.cmd.strict === false ? '...' : ''
       const a =
-        Object.values(ensureArgObject(this.cmd.args)).map((arg) =>
-          arg.required ? `${arg.name.toUpperCase()}${suffix}` : `[${arg.name.toUpperCase()}${suffix}]`,
-        ) || []
+        Object.values(ensureArgObject(this.cmd.args))
+          .filter((arg) => !arg.hidden)
+          .map((arg) =>
+            arg.required ? `${arg.name.toUpperCase()}${suffix}` : `[${arg.name.toUpperCase()}${suffix}]`,
+          ) || []
       opts.push(...a)
     }
 

--- a/test/help/docopts.test.ts
+++ b/test/help/docopts.test.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
 
-import {Flags} from '../../src'
+import {Args, Flags} from '../../src'
 import {DocOpts} from '../../src/help/docopts'
 
 describe('doc opts', () => {
@@ -56,6 +56,18 @@ describe('doc opts', () => {
       },
     } as any)
     expect(usage).to.contain(' [-s <value>]')
+  })
+
+  it('does not show hidden args', () => {
+    const usage = DocOpts.generate({
+      args: {
+        hiddenarg: Args.string({
+          name: 'hiddenarg',
+          hidden: true,
+        }),
+      },
+    } as any)
+    expect(usage.toLowerCase()).to.not.contain('hiddenarg')
   })
 
   it('does not show hidden type', () => {

--- a/test/help/format-command.test.ts
+++ b/test/help/format-command.test.ts
@@ -76,6 +76,33 @@ ALIASES
   $ oclif create`)
   })
 
+  it('should not list hidden arguments and flags', async () => {
+    const cmd = await makeLoadable(
+      makeCommandClass({
+        id: 'apps:create',
+        description: 'creates an app',
+        args: {
+          // eslint-disable-next-line camelcase
+          app_name: Args.string({description: 'app to use', hidden: true}),
+        },
+        flags: {
+          app: flags.string({char: 'a', hidden: true}),
+          foo: flags.string({required: true}),
+        },
+      }),
+    )
+
+    const output = help.formatCommand(cmd)
+    expect(output).to.equal(`USAGE
+  $ oclif apps:create --foo <value>
+
+FLAGS
+  --foo=<value>  (required)
+
+DESCRIPTION
+  creates an app`)
+  })
+
   describe('arg and flag multiline handling', () => {
     it('should show args and flags side by side when their output do not exceed 4 lines ', async () => {
       const cmd = await makeLoadable(


### PR DESCRIPTION
This addresses an issue where the hidden flag for arguments was not respected in usage output.

Theoretically I wonder if we should also be checking/throwing if trying to define commands that have hidden arguments _before_ non-hidden arguments. Eg consider:

```
args: {
  foo: Args.string({hidden: true}),
  bar: Args.string({})
}
```
… there's no way you can specify `bar` but not `foo`, so this doesn't really make sense in my book? But… a bit of scope creep, so will leave that for a later PR/someone else to figure out :)