### PR TITLE
fix: throw errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -104,6 +104,7 @@ export async function run(argv?: string[], options?: Interfaces.LoadOptions): Pr
     return await config.runCommand(id, argvSlice, cmd)
   } catch (error) {
     err = error as Error
+    throw error
   } finally {
     await runFinally(cmd, err)
   }


### PR DESCRIPTION
Fix regression in 4.5.0 that caused errors to be thrown

Fixes #1424 
Fixes #1423 