### PR TITLE
fix: indicate whether an argument is optional in the help command

### DIFF
--- a/src/help/command.ts
+++ b/src/help/command.ts
@@ -59,7 +59,8 @@ export class CommandHelp extends HelpFormatter {
 
     return args.map((a) => {
       // Add ellipsis to indicate that the argument takes multiple values if strict is false
-      const name = this.command.strict === false ? `${a.name.toUpperCase()}...` : a.name.toUpperCase()
+      let name = this.command.strict === false ? `${a.name.toUpperCase()}...` : a.name.toUpperCase()
+      name = a.required ? `${name}` : `[${name}]`
       let description = a.description || ''
       if (a.default)
         description = `${colorize(this.config?.theme?.flagDefaultValue, `[default: ${a.default}]`)} ${description}`


### PR DESCRIPTION
Makes the help command `args()` function distinguish optional arguments