### PR TITLE
fix(parser): stdin compacting issue on multiline input

### DIFF
--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-await-in-loop */
+import {EOL} from 'node:os'
 import {createInterface} from 'node:readline'
 
 import Cache from '../cache'
@@ -68,7 +69,7 @@ export const readStdin = async (): Promise<null | string> => {
   }
 
   return new Promise((resolve) => {
-    let result = ''
+    const lines: string[] = []
     const ac = new AbortController()
     const {signal} = ac
     const timeout = setTimeout(() => ac.abort(), 10)
@@ -80,10 +81,11 @@ export const readStdin = async (): Promise<null | string> => {
     })
 
     rl.on('line', (line) => {
-      result += line
+      lines.push(line)
     })
 
     rl.once('close', () => {
+      const result = lines.join(EOL)
       clearTimeout(timeout)
       debug('resolved from stdin', result)
       globalThis.oclif = {...globalThis.oclif, stdinCache: result}


### PR DESCRIPTION
Dear oclif team,

Thank you for still updating this library, I really rely on it.

I would like to propose fixing a small bug where if you provide a multiline input as `stdin`, it just compacts them into a single line.

The example would be as follows.

```shell
# call my cli with a cat into it where -stdin flag was supposed to read it as the whole file
cat test/invoice.md | LOG_LEVEL=debug ./bin/run.js -f md --stdin -O
```

```shell
@cenk1cenk2/md-printer v2.11.3
------------------------------
[D] Reading the resource from: stdin
[D] Got buffer from stdin:
[D] ---dest: ./test/test.pdftemplate: invoicedocument_title: Some MD.id: daeb87d4-a675-4867-9a95-c49b0b2aaf8adate: 26.04.2022curre ...truncated multiline string of some markdown with frontmatter that is compacted
```