### PR TITLE
chore: remove duplicate "one-way exclusive optional field" docopts test

### DIFF
--- a/test/help/docopts.test.ts
+++ b/test/help/docopts.test.ts
@@ -207,26 +207,6 @@ describe('doc opts', () => {
     expect(usage).to.contain(' (-f <value> | -s <value>)')
   })
 
-  it('shows option one-way exclusive field on optional field', () => {
-    const usage = DocOpts.generate({
-      flags: {
-        testFlag: Flags.url({
-          name: 'testFlag',
-          description: 'test',
-          char: 's',
-        }),
-        testFlag2: Flags.string({
-          name: 'testFlag2',
-          description: 'test',
-          char: 'f',
-          required: true,
-          exclusive: ['testFlag'],
-        }),
-      },
-    } as any)
-    expect(usage).to.contain(' (-f <value> | -s <value>)')
-  })
-
   it('shows optional exclusive fields defined twice', () => {
     const usage = DocOpts.generate({
       flags: {


### PR DESCRIPTION
The input & output of the removed test is exactly the same as the one right above
https://github.com/oclif/core/blob/v1.16.4/test/help/docopts.test.ts#L148-L182