### PR TITLE
test: correct optional one-way exclusive field test case

### DIFF
--- a/test/help/docopts.test.ts
+++ b/test/help/docopts.test.ts
@@ -207,7 +207,7 @@ describe('doc opts', () => {
     expect(usage).to.contain(' (-f <value> | -s <value>)')
   })
 
-  it('shows option one-way exclusive field on optional field', () => {
+  it('shows optional one-way exclusive field on optional field', () => {
     const usage = DocOpts.generate({
       flags: {
         testFlag: Flags.url({
@@ -219,12 +219,11 @@ describe('doc opts', () => {
           name: 'testFlag2',
           description: 'test',
           char: 'f',
-          required: true,
           exclusive: ['testFlag'],
         }),
       },
     } as any)
-    expect(usage).to.contain(' (-f <value> | -s <value>)')
+    expect(usage).to.contain(' [-f <value> | -s <value>]')
   })
 
   it('shows optional exclusive fields defined twice', () => {


### PR DESCRIPTION
The test's body was previously a duplicate of the "shows required one-way exclusive field on optional field" test, right above. 
As suggested by https://github.com/oclif/core/pull/1461#issuecomment-3390921329