### PR TITLE
feat(W-15161040): show env in flag help

### DIFF
--- a/src/help/command.ts
+++ b/src/help/command.ts
@@ -190,9 +190,25 @@ export class CommandHelp extends HelpFormatter {
       if (noChar) left = left.replace('    ', '')
 
       let right = flag.summary || flag.description || ''
+
+      // Build metadata string (default, env, or both)
+      const metadata: string[] = []
       const canBeCached = !(this.opts.respectNoCacheDefault === true && flag.noCacheDefault === true)
-      if (flag.type === 'option' && flag.default && canBeCached) {
-        right = `${colorize(this.config?.theme?.flagDefaultValue, `[default: ${flag.default}]`)} ${right}`
+
+      if (flag.type === 'option') {
+        if (flag.default && canBeCached) {
+          metadata.push(`default: ${flag.default}`)
+        }
+
+        if (flag.env) {
+          metadata.push(`env: ${flag.env}`)
+        }
+      } else if (flag.type === 'boolean' && flag.env) {
+        metadata.push(`env: ${flag.env}`)
+      }
+
+      if (metadata.length > 0) {
+        right = `${colorize(this.config?.theme?.flagDefaultValue, `[${metadata.join(', ')}]`)} ${right}`
       }
 
       if (flag.required) right = `${colorize(this.config?.theme?.flagRequired, '(required)')} ${right}`


### PR DESCRIPTION
Improves flag help output by displaying environment variable configuration alongside existing default value display.

### Changes
Option flags now show:
  - `[default: xxx]` when a default value exists (already existed)
  - `[env: XXX]` when an environment variable is configured (new)
  - `[default: xxx, env: XXX]` when both are present (new)

Boolean flags now show:
  - `[env: XXX]` when an environment variable is configured (new)

### Example
Before:

```
FLAGS
  --api-key=<value>  [default: abc123] Your API key
  --debug            Enable debug mode
```

After:

```
FLAGS
  --api-key=<value>  [default: abc123, env: API_KEY] Your API key
  --debug            [env: DEBUG] Enable debug mode
```

Fixes #981 
@W-15161040@