### PR TITLE
fix(W-17318299): retain description when hiding summary in help

### DIFF
--- a/src/help/command.ts
+++ b/src/help/command.ts
@@ -93,7 +93,7 @@ export class CommandHelp extends HelpFormatter {
 
     let description: string[] | undefined
     if (this.opts.hideCommandSummaryInDescription) {
-      description = (cmd.description || '').split(POSSIBLE_LINE_FEED).slice(1)
+      description = [(cmd.description || '').split(POSSIBLE_LINE_FEED).at(-1) ?? '']
     } else if (cmd.description) {
       const summary = cmd.summary ? `${cmd.summary}\n` : null
       description = summary

--- a/test/help/format-command-with-options.test.ts
+++ b/test/help/format-command-with-options.test.ts
@@ -114,6 +114,9 @@ OPTIONS
                        newliney
                        newliney
 
+DESCRIPTION
+  description of apps:create
+
 ALIASES
   $ oclif app:init
   $ oclif create`)
@@ -170,6 +173,9 @@ OPTIONS
       newliney
       newliney
       newliney
+
+DESCRIPTION
+  description of apps:create
 
 ALIASES
   $ oclif app:init


### PR DESCRIPTION
Fixes a bug that caused the description to be lost when the `hideSummaryInDescription` option is enabled for help output. See original issue for repro steps

Fixes #1243
@W-17318299@