### PR TITLE
feat: add `Args.option()` for typed arg options

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -99,7 +99,7 @@ type ReadonlyElementOf<T extends ReadonlyArray<unknown>> = T[number]
  * }
  */
 export function option<T extends readonly string[]>(
-  defaults: Partial<Arg<ReadonlyElementOf<T>>> & {options: T},
+  defaults: Omit<Partial<Arg<ReadonlyElementOf<T>>>, 'default' | 'multiple' | 'required'> & {options: T},
 ): ArgDefinition<(typeof defaults.options)[number]> {
   return (options: any = {}) => ({
     parse: async (i: string, _context: Command, _opts: Record<string, unknown>) => i,

--- a/src/args.ts
+++ b/src/args.ts
@@ -81,3 +81,31 @@ export const url = custom<URL>({
 
 const stringArg = custom({})
 export {stringArg as string}
+
+type ReadonlyElementOf<T extends ReadonlyArray<unknown>> = T[number]
+
+/**
+ * Create an arg that infers the type from the provided options.
+ *
+ * The provided `options` must be a readonly array in order for type inference to work.
+ *
+ * @example
+ * export default class MyCommand extends Command {
+ *   static args = {
+ *     stage: Args.option({
+ *       options: ['production', 'staging', 'development'] as const,
+ *     })(),
+ *   }
+ * }
+ */
+export function option<T extends readonly string[]>(
+  defaults: Partial<Arg<ReadonlyElementOf<T>>> & {options: T},
+): ArgDefinition<(typeof defaults.options)[number]> {
+  return (options: any = {}) => ({
+    parse: async (i: string, _context: Command, _opts: Record<string, unknown>) => i,
+    ...defaults,
+    ...options,
+    input: [] as string[],
+    type: 'option',
+  })
+}

--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -204,7 +204,7 @@ export type ArgProps = {
    */
   multiple?: boolean
 
-  options?: string[]
+  options?: readonly string[]
   ignoreStdin?: boolean
   /**
    * If true, the value returned by defaultHelp will not be cached in the oclif.manifest.json.
@@ -262,7 +262,7 @@ export type ArgParser<T, P = CustomOptions> = (
 ) => Promise<T>
 
 export type Arg<T, P = CustomOptions> = ArgProps & {
-  options?: T[]
+  options?: readonly T[]
   defaultHelp?: ArgDefaultHelp<T>
   input: string[]
   default?: ArgDefault<T | undefined>

--- a/test/interfaces/args.test-types.ts
+++ b/test/interfaces/args.test-types.ts
@@ -12,11 +12,17 @@ type MyType = {
   foo: boolean
 }
 
+const stages = ['production', 'staging', 'development'] as const
+
 export class MyCommand extends Command {
   static args = {
     requiredString: Args.string({required: true}),
     optionalString: Args.string(),
     defaultString: Args.string({default: 'default'}),
+
+    optionalOption: Args.option({options: stages})(),
+    requiredOption: Args.option({options: stages})({required: true}),
+    defaultOption: Args.option({options: stages})({default: 'production'}),
 
     requiredBoolean: Args.boolean({required: true}),
     optionalBoolean: Args.boolean(),
@@ -114,6 +120,12 @@ export class MyCommand extends Command {
     expectType<string[]>(this.args.defaultVariadic)
     expectNotType<undefined>(this.args.defaultVariadic)
     expectType<string[] | undefined>(this.args.optionalVariadic)
+
+    expectType<(typeof stages)[number]>(this.args.requiredOption)
+    expectNotType<undefined>(this.args.requiredOption)
+    expectType<(typeof stages)[number]>(this.args.defaultOption)
+    expectNotType<undefined>(this.args.defaultOption)
+    expectType<(typeof stages)[number] | undefined>(this.args.optionalOption)
 
     return result.args
   }

--- a/test/interfaces/args.test-types.ts
+++ b/test/interfaces/args.test-types.ts
@@ -24,6 +24,10 @@ export class MyCommand extends Command {
     requiredOption: Args.option({options: stages})({required: true}),
     defaultOption: Args.option({options: stages})({default: 'production'}),
 
+    optionalMultipleOption: Args.option({options: stages})({multiple: true}),
+    requiredMultipleOption: Args.option({options: stages})({multiple: true, required: true}),
+    defaultMultipleOption: Args.option({options: stages})({multiple: true, default: ['production']}),
+
     requiredBoolean: Args.boolean({required: true}),
     optionalBoolean: Args.boolean(),
     defaultBoolean: Args.boolean({default: true}),
@@ -126,6 +130,12 @@ export class MyCommand extends Command {
     expectType<(typeof stages)[number]>(this.args.defaultOption)
     expectNotType<undefined>(this.args.defaultOption)
     expectType<(typeof stages)[number] | undefined>(this.args.optionalOption)
+
+    expectType<(typeof stages)[number][]>(this.args.requiredMultipleOption)
+    expectNotType<undefined>(this.args.requiredMultipleOption)
+    expectType<(typeof stages)[number][]>(this.args.defaultMultipleOption)
+    expectNotType<undefined>(this.args.defaultMultipleOption)
+    expectType<(typeof stages)[number][] | undefined>(this.args.optionalMultipleOption)
 
     return result.args
   }

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -1376,6 +1376,76 @@ See more help with --help`)
 
       expect(message).to.include('Expected invalidopt to be one of: myopt, myotheropt')
     })
+
+    describe('Args.option()', () => {
+      const stages = ['production', 'staging', 'development'] as const
+
+      it('parses a single valid option', async () => {
+        const out = await parse(['staging'], {
+          args: {stage: Args.option({options: stages})()},
+        })
+        expect(out.args.stage).to.equal('staging')
+      })
+
+      it('rejects an invalid option', async () => {
+        try {
+          await parse(['invalid'], {
+            args: {stage: Args.option({options: stages})()},
+          })
+          assert.fail('Expected error')
+        } catch (error: unknown) {
+          if (error instanceof Error) {
+            expect(error.message).to.include('Expected invalid to be one of: production, staging, development')
+          } else {
+            assert.fail('Expected an Error instance')
+          }
+        }
+      })
+
+      it('applies the default when the arg is omitted', async () => {
+        const out = await parse([], {
+          args: {stage: Args.option({options: stages})({default: 'production'})},
+        })
+        expect(out.args.stage).to.equal('production')
+      })
+
+      it('errors when a required option is missing', async () => {
+        try {
+          await parse([], {
+            args: {stage: Args.option({options: stages})({required: true})},
+          })
+          assert.fail('Expected error')
+        } catch (error: unknown) {
+          if (error instanceof Error) {
+            expect(error.message).to.include('Missing 1 required arg')
+          } else {
+            assert.fail('Expected an Error instance')
+          }
+        }
+      })
+
+      it('parses multiple valid options', async () => {
+        const out = await parse(['production', 'staging', 'development'], {
+          args: {stage: Args.option({options: stages})({multiple: true})},
+        })
+        expect(out.args.stage).to.deep.equal(['production', 'staging', 'development'])
+      })
+
+      it('rejects when one of multiple options is invalid', async () => {
+        try {
+          await parse(['production', 'invalid'], {
+            args: {stage: Args.option({options: stages})({multiple: true})},
+          })
+          assert.fail('Expected error')
+        } catch (error: unknown) {
+          if (error instanceof Error) {
+            expect(error.message).to.include('Expected invalid to be one of: production, staging, development')
+          } else {
+            assert.fail('Expected an Error instance')
+          }
+        }
+      })
+    })
   })
 
   describe('env', () => {


### PR DESCRIPTION
Adds a new `Args.option()` method mirroring `Flags.option()`, which provides type-safe option usage:

```ts
class Deploy extends Command {
  static args = {
    env: Args.option({
      options: ['production', 'staging', 'development'] as const
    })()
  }

  async run() {
    const {args} = await this.parse(Deploy)
    // `args.env` typed as `'production' | 'staging' | 'development' | undefined`
  }
}
```

Setting it as `required` removes the `undefined` from the union.