### PR TITLE
fix: updating tinyglobby dependency [skip-validate-pr]

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "semver": "^7.8.0",
     "string-width": "^4.2.3",
     "supports-color": "^8",
-    "tinyglobby": "^0.2.14",
+    "tinyglobby": "^0.2.16",
     "widest-line": "^3.1.0",
     "wordwrap": "^1.0.0",
     "wrap-ansi": "^7.0.0"
@@ -40,6 +40,7 @@
     "@types/indent-string": "^4.0.1",
     "@types/mocha": "^10.0.10",
     "@types/node": "^18",
+    "@types/picomatch": "^4.0.3",
     "@types/pnpapi": "^0.0.5",
     "@types/sinon": "^17.0.3",
     "@types/supports-color": "^8.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,6 +1184,11 @@
   resolved "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
+"@types/picomatch@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/picomatch/-/picomatch-4.0.3.tgz#d92bbf24166478c5457c8bb9ba41a7f49d55e094"
+  integrity sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==
+
 "@types/pnpapi@^0.0.5":
   version "0.0.5"
   resolved "https://registry.npmjs.org/@types/pnpapi/-/pnpapi-0.0.5.tgz"
@@ -5869,6 +5874,11 @@ picomatch@^4.0.2, picomatch@^4.0.3:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
+picomatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+
 pidtree@^0.6.0:
   version "0.6.0"
   resolved "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz"
@@ -6956,6 +6966,14 @@ tinyglobby@^0.2.13, tinyglobby@^0.2.14:
   dependencies:
     fdir "^6.4.4"
     picomatch "^4.0.2"
+
+tinyglobby@^0.2.16:
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.16.tgz#1c3b7eb953fce42b226bc5a1ee06428281aff3d6"
+  integrity sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
 
 to-fast-properties@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
PR #1579 ups `tinyglobby`, but that PR fails to build because it needs a types dependency for `picomatch`. This makes the dependency upgrade and also adds the type dependency so that the build can pass.