### PR TITLE
fix: windows shell identification is more reliable @W-22969497@

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,7 +1,6 @@
 import * as ejs from 'ejs'
-import {execSync} from 'node:child_process'
-import {arch, userInfo as osUserInfo, release, tmpdir, type} from 'node:os'
-import {join, resolve, sep} from 'node:path'
+import {arch, release, tmpdir, type} from 'node:os'
+import {join, resolve} from 'node:path'
 import {fileURLToPath, URL} from 'node:url'
 
 import Cache from '../cache'
@@ -19,7 +18,7 @@ import {settings} from '../settings'
 import {determinePriority} from '../util/determine-priority'
 import {safeReadJson} from '../util/fs'
 import {toStandardizedId} from '../util/ids'
-import {getHomeDir, getPlatform} from '../util/os'
+import {getHomeDir, getPlatform, getShell} from '../util/os'
 import {compact, isProd} from '../util/util'
 import {ux} from '../ux'
 import {parseTheme} from '../ux/theme'
@@ -180,20 +179,6 @@ export class Config implements IConfig {
     }
   }
 
-  protected _shell(): string {
-    let shellPath
-    const SHELL = process.env.SHELL ?? osUserInfo().shell?.split(sep)?.pop()
-    if (SHELL) {
-      shellPath = SHELL.split('/')
-    } else if (this.windows) {
-      shellPath = [this.determineWindowsShell()]
-    } else {
-      shellPath = ['unknown']
-    }
-
-    return shellPath.at(-1) ?? 'unknown'
-  }
-
   protected dir(category: 'cache' | 'config' | 'data'): string {
     const base =
       process.env[`XDG_${category.toUpperCase()}_HOME`] ||
@@ -324,7 +309,7 @@ export class Config implements IConfig {
     if (this.platform === 'win32') this.dirname = this.dirname.replace('/', '\\')
 
     this.userAgent = `${this.name}/${this.version} ${this.platform}-${this.arch} node-${process.version}`
-    this.shell = this._shell()
+    this.shell = getShell()
 
     this.home = process.env.HOME || (this.windows && this.windowsHome()) || getHomeDir() || tmpdir()
     this.cacheDir = this.scopedEnvVar('CACHE_DIR') || this.macosCacheDir() || this.dir('cache')
@@ -679,20 +664,6 @@ export class Config implements IConfig {
       bucket,
       host,
       templates,
-    }
-  }
-
-  private determineWindowsShell(): string {
-    try {
-      const parentProcessName = execSync(
-        `powershell.exe -NoProfile -Command "(Get-CimInstance Win32_Process -Filter 'ProcessID = ${process.ppid}').Name"`,
-        {encoding: 'utf8'},
-      )
-      return parentProcessName.includes('powershell') || parentProcessName.includes('pwsh')
-        ? 'powershell'
-        : (process.env.COMSPEC ?? 'cmd.exe')
-    } catch {
-      return process.env.COMSPEC ?? 'cmd.exe'
     }
   }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,4 +1,5 @@
 import * as ejs from 'ejs'
+import {execSync} from 'node:child_process'
 import {arch, userInfo as osUserInfo, release, tmpdir, type} from 'node:os'
 import {join, resolve, sep} from 'node:path'
 import {fileURLToPath, URL} from 'node:url'
@@ -181,22 +182,11 @@ export class Config implements IConfig {
 
   protected _shell(): string {
     let shellPath
-    const {COMSPEC} = process.env
     const SHELL = process.env.SHELL ?? osUserInfo().shell?.split(sep)?.pop()
     if (SHELL) {
       shellPath = SHELL.split('/')
-    } else if (
-      this.windows &&
-      (process.title.toLowerCase().includes('powershell') || process.title.toLowerCase().includes('pwsh'))
-    ) {
-      shellPath = ['powershell']
-    } else if (
-      this.windows &&
-      (process.title.toLowerCase().includes('command prompt') || process.title.toLowerCase().includes('cmd'))
-    ) {
-      shellPath = ['cmd.exe']
-    } else if (this.windows && COMSPEC) {
-      shellPath = COMSPEC.split(/\\|\//)
+    } else if (this.windows) {
+      shellPath = [this.determineWindowsShell()]
     } else {
       shellPath = ['unknown']
     }
@@ -211,8 +201,8 @@ export class Config implements IConfig {
       join(this.home, category === 'data' ? '.local/share' : '.' + category)
     return join(base, this.dirname)
   }
-  public findCommand(id: string, opts: {must: true}): Command.Loadable
 
+  public findCommand(id: string, opts: {must: true}): Command.Loadable
   public findCommand(id: string, opts?: {must: boolean}): Command.Loadable | undefined
 
   public findCommand(id: string, opts: {must?: boolean} = {}): Command.Loadable | undefined {
@@ -689,6 +679,20 @@ export class Config implements IConfig {
       bucket,
       host,
       templates,
+    }
+  }
+
+  private determineWindowsShell(): string {
+    try {
+      const parentProcessName = execSync(
+        `powershell.exe -NoProfile -Command "(Get-CimInstance Win32_Process -Filter 'ProcessID - ${process.ppid}').Name"`,
+        {encoding: 'utf8'},
+      )
+      return parentProcessName.includes('powershell') || parentProcessName.includes('pwsh')
+        ? 'powershell'
+        : (process.env.COMSPEC ?? 'cmd.exe')
+    } catch {
+      return process.env.COMSPEC ?? 'cmd.exe'
     }
   }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -685,7 +685,7 @@ export class Config implements IConfig {
   private determineWindowsShell(): string {
     try {
       const parentProcessName = execSync(
-        `powershell.exe -NoProfile -Command "(Get-CimInstance Win32_Process -Filter 'ProcessID - ${process.ppid}').Name"`,
+        `powershell.exe -NoProfile -Command "(Get-CimInstance Win32_Process -Filter 'ProcessID = ${process.ppid}').Name"`,
         {encoding: 'utf8'},
       )
       return parentProcessName.includes('powershell') || parentProcessName.includes('pwsh')

--- a/src/util/os.ts
+++ b/src/util/os.ts
@@ -1,5 +1,7 @@
 import WSL from 'is-wsl'
-import {homedir, platform} from 'node:os'
+import {execSync} from 'node:child_process'
+import {homedir, userInfo as osUserInfo, platform} from 'node:os'
+import path from 'node:path'
 
 /**
  * Call os.homedir() and return the result
@@ -23,4 +25,32 @@ export function getHomeDir(): string {
  */
 export function getPlatform(): 'wsl' | NodeJS.Platform {
   return WSL ? 'wsl' : platform()
+}
+
+export function getShell(): string {
+  let shellPath
+  const SHELL = process.env.SHELL ?? osUserInfo().shell?.split(path.sep)?.pop()
+  if (SHELL) {
+    shellPath = SHELL.split('/')
+  } else if (getPlatform() === 'win32') {
+    shellPath = [determineWindowsShell()]
+  } else {
+    shellPath = ['unknown']
+  }
+
+  return shellPath.at(-1) ?? 'unknown'
+}
+
+function determineWindowsShell(): string {
+  try {
+    const parentProcessName = execSync(
+      `powershell.exe -NoProfile -Command "(Get-CimInstance Win32_Process -Filter 'ProcessID = ${process.ppid}').Name"`,
+      {encoding: 'utf8'},
+    )
+    return parentProcessName.includes('powershell') || parentProcessName.includes('pwsh')
+      ? 'powershell'
+      : (process.env.COMSPEC ?? 'cmd.exe')
+  } catch {
+    return process.env.COMSPEC ?? 'cmd.exe'
+  }
 }

--- a/src/util/os.ts
+++ b/src/util/os.ts
@@ -33,7 +33,7 @@ export function getShell(): string {
   if (SHELL) {
     shellPath = SHELL.split('/')
   } else if (getPlatform() === 'win32') {
-    shellPath = [determineWindowsShell()]
+    shellPath = determineWindowsShell().split(path.sep)
   } else {
     shellPath = ['unknown']
   }

--- a/test/config/config.shell.test.ts
+++ b/test/config/config.shell.test.ts
@@ -23,7 +23,6 @@ describe('config shell', () => {
       },
     })
     await config.load()
-    // @ts-expect-error because _shell is private
-    expect(config._shell()).to.equal(getShell(), `SHELL: ${process.env.SHELL} COMSPEC: ${process.env.COMSPEC}`)
+    expect(config.shell).to.equal(getShell(), `SHELL: ${process.env.SHELL} COMSPEC: ${process.env.COMSPEC}`)
   })
 })

--- a/test/config/config.shell.test.ts
+++ b/test/config/config.shell.test.ts
@@ -5,7 +5,10 @@ import {sep} from 'node:path'
 import {Config} from '../../src'
 
 const getShell = () =>
-  osUserInfo().shell?.split(sep)?.pop() || (process.platform === 'win32' ? 'powershell' : 'unknown')
+  osUserInfo().shell?.split(sep)?.pop() ||
+  // When you use yarn or npx or whatever to run the tests on Windows, it will use the system's default shell, which
+  // derived from COMSPEC and is almost always 'cmd.exe'
+  (process.platform === 'win32' ? 'cmd.exe' : 'unknown')
 
 describe('config shell', () => {
   it('has a default shell', async () => {


### PR DESCRIPTION
This fixes the @oclif/core tests which were broken on `main` in Windows running on Node v24.16.0.
This is an issue with [Node itself](https://github.com/nodejs/node/issues/63858), wherein the output for `process.title` changed in between node minor versions, which broke some of our code that depends on it having a certain range of values.

 Since we have no timeline on a fix from Node, I workshopped an alternative workaround. This should be more reliable than the previous version at determining what shell is being used on a Windows machine, but it has the downside of doing an `execSync` call, which adds about a half-second of execution time on Windows exclusively.

I'm not sure any alternative workaround exists, so we either need to wait for Node to fix it in their own time, or accept the slight performance hit.

This fixes work item @W-22969497@