### PR TITLE
fix: include error message in --json output

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -302,6 +302,13 @@ export abstract class Command {
   public abstract run(): Promise<any>
 
   protected toErrorJson(err: unknown): any {
+    if (err instanceof Error) {
+      // `Error.prototype.message`/`.name` are non-enumerable, so they are dropped
+      // by `JSON.stringify` in `logJson`. Surface them explicitly while preserving
+      // any enumerable own properties (e.g. a `CLIError`'s `oclif` metadata).
+      return {error: {...err, message: err.message, name: err.name}}
+    }
+
     return {error: err}
   }
 

--- a/test/command/command.test.ts
+++ b/test/command/command.test.ts
@@ -1,7 +1,7 @@
 import {captureOutput} from '@oclif/test'
 import {expect} from 'chai'
 
-import {Command as Base, Flags} from '../../src'
+import {Command as Base, Errors, Flags} from '../../src'
 
 class Command extends Base {
   static description = 'test command'
@@ -370,6 +370,36 @@ describe('command', () => {
 
       const cmd = new CMD(['--json'], {} as any)
       expect(cmd.jsonEnabled()).to.equal(false)
+    })
+  })
+
+  describe('--json error rendering', () => {
+    it('includes the message of a plain Error', async () => {
+      class CMD extends Command {
+        static enableJsonFlag = true
+
+        async run() {
+          throw new Error('boom under json')
+        }
+      }
+
+      const {stdout} = await captureOutput(async () => CMD.run(['--json']))
+      expect(JSON.parse(stdout).error.message).to.equal('boom under json')
+    })
+
+    it('includes the message of a CLIError alongside its oclif metadata', async () => {
+      class CMD extends Command {
+        static enableJsonFlag = true
+
+        async run() {
+          throw new Errors.CLIError('kaboom under json')
+        }
+      }
+
+      const {stdout} = await captureOutput(async () => CMD.run(['--json']))
+      const json = JSON.parse(stdout)
+      expect(json.error.message).to.equal('kaboom under json')
+      expect(json.error.oclif.exit).to.equal(2)
     })
   })
 })


### PR DESCRIPTION
Closes #1608.

When a command with `enableJsonFlag` errors, `--json` mode serializes the error via `toErrorJson()`, which returned `{error: err}`. `JSON.stringify` (in `logJson`) then drops `Error.prototype.message`/`.name`/`.stack` because they are non-enumerable own properties, so the user-facing message is lost:

```
$ mycmd --json          # throw new Error('...')
{ "error": {} }
$ mycmd --json          # throw new Errors.CLIError('...')
{ "error": { "oclif": { "exit": 2 } } }
```

This affects all three idiomatic patterns: `throw new Error(...)`, `throw new Errors.CLIError(...)`, and `this.error(...)`.

### Fix
In `toErrorJson`, when the error is an `Error`, serialize `message`/`name` explicitly while spreading enumerable own properties, so existing structural fields (e.g. a `CLIError`'s `oclif` metadata) are preserved and the message is surfaced. Non-`Error` values are passed through unchanged.

### Tests
Two `--json error rendering` tests, red before the change and green after — a plain `Error` and a `CLIError` (asserting the message is present and `oclif.exit` is still emitted). Full `test/command` + `test/errors` suites pass.