### PR TITLE
fix: merge execute load options with dir

### DIFF
--- a/src/execute.ts
+++ b/src/execute.ts
@@ -1,9 +1,21 @@
+import {fileURLToPath} from 'node:url'
+
 import {CLIError} from './errors'
 import {handle} from './errors/handle'
 import {flush} from './flush'
-import {LoadOptions} from './interfaces'
+import {LoadOptions, Options} from './interfaces'
 import {run} from './main'
 import {settings} from './settings'
+
+type ExecuteLoadOptions = LoadOptions | (Omit<Options, 'root'> & {root?: string})
+
+function resolveLoadOptions(dir?: string, loadOptions?: ExecuteLoadOptions): LoadOptions {
+  if (!dir || !loadOptions || typeof loadOptions === 'string' || '_base' in loadOptions) {
+    return (loadOptions ?? dir) as LoadOptions
+  }
+
+  return {root: dir.startsWith('file://') ? fileURLToPath(dir) : dir, ...loadOptions}
+}
 
 /**
  * Load and run oclif CLI
@@ -46,7 +58,7 @@ export async function execute(options: {
   args?: string[]
   development?: boolean
   dir?: string
-  loadOptions?: LoadOptions
+  loadOptions?: ExecuteLoadOptions
 }): Promise<unknown> {
   if (!options.dir && !options.loadOptions) {
     throw new CLIError('dir or loadOptions is required.')
@@ -58,7 +70,7 @@ export async function execute(options: {
     settings.debug = true
   }
 
-  return run(options.args ?? process.argv.slice(2), options.loadOptions ?? options.dir)
+  return run(options.args ?? process.argv.slice(2), resolveLoadOptions(options.dir, options.loadOptions))
     .then(async (result) => {
       flush()
       return result

--- a/test/execute.test.ts
+++ b/test/execute.test.ts
@@ -1,0 +1,22 @@
+import {captureOutput} from '@oclif/test'
+import {expect} from 'chai'
+import {resolve} from 'node:path'
+import {pathToFileURL} from 'node:url'
+
+import {execute} from '../src/execute'
+
+describe('execute', () => {
+  it('infers root from dir when loadOptions are provided', async () => {
+    const dir = pathToFileURL(resolve(__dirname, 'command/fixtures/esm/package.json')).toString()
+    const {error, stdout} = await captureOutput(() =>
+      execute({
+        args: ['--version'],
+        dir,
+        loadOptions: {ignoreManifest: true},
+      }),
+    )
+
+    expect(error).to.be.undefined
+    expect(stdout).to.include('oclif-esm/0.0.0')
+  })
+})


### PR DESCRIPTION
## What changed

- merge `execute()`'s `dir` with partial `loadOptions`
- preserve explicitly supplied load options such as `ignoreManifest`
- normalize file URL roots before loading the CLI
- add a regression test covering `dir` plus `{ignoreManifest: true}`

## Why

Passing `loadOptions` currently replaces `dir` entirely, so inferred values such as `root` are lost. Supplying only `ignoreManifest` then reaches the loader without a root and fails before the option can take effect.

Fixes #1533.

## Checks

- `yarn compile --noEmit`
- focused Mocha test on Node 22: `test/execute.test.ts`
- `yarn lint` (passes with existing warnings)
- ESLint and Prettier checks for the changed files

Prepared with Codex assistance; the diff was reviewed and the checks above were run locally.
