### PR TITLE
feat: expose root help formatter

### DIFF
--- a/src/help/index.ts
+++ b/src/help/index.ts
@@ -137,7 +137,7 @@ export class Help extends HelpBase {
     return this.section('COMMANDS', body)
   }
 
-  protected formatRoot(): string {
+  public formatRoot(): string {
     const help = new RootHelp(this.config, this.opts)
     return help.root()
   }

--- a/test/help/format-root.test.ts
+++ b/test/help/format-root.test.ts
@@ -21,7 +21,6 @@ describe('formatRoot', () => {
   })
 
   function getRootHelp(): string {
-    // @ts-expect-error private member
     const root = new Help(config).formatRoot()
     return ansis
       .strip(root)


### PR DESCRIPTION
## Summary

- make `Help.formatRoot()` a public API for callers that need to compose or extend root help
- remove the TypeScript suppression from the existing root-help test so visibility regressions fail compilation
- preserve the existing root help output and runtime behavior

## Validation

- `npx --yes yarn@1.22.22 mocha --forbid-only test/help/format-root.test.ts` (5 passing)
- `npx --yes yarn@1.22.22 compile --noEmit`
- `npx --yes yarn@1.22.22 eslint src/help/index.ts test/help/format-root.test.ts`
- `npx --yes yarn@1.22.22 test` (821 passing; full lint, build, and circular-dependency check also passed; 8 pre-existing lint warnings outside this diff)
- `npm pack --dry-run --json --ignore-scripts` (163 files)

Closes #1284

## AI disclosure

This contribution was implemented with assistance from OpenAI Codex. The scope, diff, and validation results are documented above.