### PR TITLE
fix: replaced require with dynamic import (W-23807278)

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -296,7 +296,7 @@ export class Config implements IConfig {
     this.valid = this.rootPlugin.valid
 
     this.arch = arch() === 'ia32' ? 'x86' : (arch() as any)
-    this.platform = getPlatform()
+    this.platform = await getPlatform()
     this.windows = this.platform === 'win32'
     this.bin = this.pjson.oclif.bin || this.name
     this.binAliases = this.pjson.oclif.binAliases

--- a/src/util/os.ts
+++ b/src/util/os.ts
@@ -2,9 +2,6 @@ import {execSync} from 'node:child_process'
 import {homedir, userInfo as osUserInfo, platform} from 'node:os'
 import path from 'node:path'
 
-// eslint-disable-next-line perfectionist/sort-imports -- Conflicts with other import rules in the case of `require` statements.
-const wslUtils = require('wsl-utils')
-
 /**
  * Call os.homedir() and return the result
  *
@@ -25,8 +22,8 @@ export function getHomeDir(): string {
  *
  * @returns The process' platform
  */
-export function getPlatform(): 'wsl' | NodeJS.Platform {
-  return wslUtils.isWsl ? 'wsl' : platform()
+export async function getPlatform(): Promise<'wsl' | NodeJS.Platform> {
+  return (await import('wsl-utils')).isWsl ? 'wsl' : platform()
 }
 
 export async function getShell(): Promise<string> {
@@ -34,7 +31,7 @@ export async function getShell(): Promise<string> {
   const SHELL = process.env.SHELL ?? osUserInfo().shell?.split(path.sep)?.pop()
   if (SHELL) {
     shellPath = SHELL.split('/')
-  } else if (getPlatform() === 'win32') {
+  } else if ((await getPlatform()) === 'win32') {
     shellPath = (await determineWindowsShell()).split(path.sep)
   } else {
     shellPath = ['unknown']
@@ -46,7 +43,7 @@ export async function getShell(): Promise<string> {
 async function determineWindowsShell(): Promise<string> {
   try {
     const parentProcessName = execSync(
-      `${await wslUtils.powerShellPath()} -NoProfile -Command "(Get-CimInstance Win32_Process -Filter 'ProcessID = ${process.ppid}').Name"`,
+      `${await (await import('wsl-utils')).powerShellPath()} -NoProfile -Command "(Get-CimInstance Win32_Process -Filter 'ProcessID = ${process.ppid}').Name"`,
       {encoding: 'utf8'},
     )
     return parentProcessName.includes('powershell') || parentProcessName.includes('pwsh')

--- a/test/command/main-esm.test.ts
+++ b/test/command/main-esm.test.ts
@@ -10,11 +10,16 @@ const convertToFileURL = (filepath: string) => pathToFileURL(filepath).toString(
 
 let root = resolve(__dirname, '../../package.json')
 const pjson = require(root)
-const version = `@oclif/core/${pjson.version} ${getPlatform()}-${process.arch} node-${process.version}`
 
 root = convertToFileURL(root)
 
 describe('main-esm', () => {
+  let version: string
+
+  before(async () => {
+    version = `@oclif/core/${pjson.version} ${await getPlatform()}-${process.arch} node-${process.version}`
+  })
+
   it('runs plugins', async () => {
     const {stdout} = await runCommand(['plugins'], {root})
     expect(stdout).to.equal('No plugins installed.\n')

--- a/test/command/main.test.ts
+++ b/test/command/main.test.ts
@@ -6,9 +6,14 @@ import {join, resolve} from 'node:path'
 import {getPlatform} from '../../src/util/os'
 
 const pjson = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf8'))
-const version = `@oclif/core/${pjson.version} ${getPlatform()}-${process.arch} node-${process.version}`
 
 describe('main', () => {
+  let version: string
+
+  before(async () => {
+    version = `@oclif/core/${pjson.version} ${await getPlatform()}-${process.arch} node-${process.version}`
+  })
+
   it('should run plugins', async () => {
     const {result} = await runCommand<
       Array<{

--- a/test/config/config.flexible.test.ts
+++ b/test/config/config.flexible.test.ts
@@ -43,7 +43,7 @@ describe('Config with flexible taxonomy', () => {
 
   async function loadConfig({commandIds = ['foo:bar', 'foo:baz'], types = []}: Options = {}) {
     sinon.stub(os, 'getHomeDir').returns('/my/home')
-    sinon.stub(os, 'getPlatform').returns('darwin')
+    sinon.stub(os, 'getPlatform').resolves('darwin')
 
     const load = async (): Promise<void> => {}
     const findCommand = async (): Promise<Command.Class> => MyCommandClass

--- a/test/config/config.test.ts
+++ b/test/config/config.test.ts
@@ -116,7 +116,7 @@ describe('Config', () => {
   describe('darwin', () => {
     it('should have darwin specific paths', async () => {
       sinon.stub(os, 'getHomeDir').returns(join('/my/home'))
-      sinon.stub(os, 'getPlatform').returns('darwin')
+      sinon.stub(os, 'getPlatform').resolves('darwin')
       const config = await Config.load()
 
       expect(config).to.have.property('cacheDir', join('/my/home/Library/Caches/@oclif/core'))
@@ -129,7 +129,7 @@ describe('Config', () => {
   describe('linux', () => {
     it('should have linux specific paths', async () => {
       sinon.stub(os, 'getHomeDir').returns(join('/my/home'))
-      sinon.stub(os, 'getPlatform').returns('linux')
+      sinon.stub(os, 'getPlatform').resolves('linux')
       const config = await Config.load()
 
       expect(config).to.have.property('cacheDir', join('/my/home/.cache/@oclif/core'))
@@ -142,7 +142,7 @@ describe('Config', () => {
   describe('win32', () => {
     it('should have win32 specific paths', async () => {
       sinon.stub(os, 'getHomeDir').returns(join('/my/home'))
-      sinon.stub(os, 'getPlatform').returns('win32')
+      sinon.stub(os, 'getPlatform').resolves('win32')
       process.env.LOCALAPPDATA = '/my/home/localappdata'
       const config = await Config.load()
 
@@ -248,7 +248,7 @@ describe('Config', () => {
   describe('findCommand', () => {
     async function loadConfig({commandIds = ['foo:bar', 'foo:baz'], types = []}: Options = {}) {
       sinon.stub(os, 'getHomeDir').returns('/my/home')
-      sinon.stub(os, 'getPlatform').returns('darwin')
+      sinon.stub(os, 'getPlatform').resolves('darwin')
 
       class MyCommandClass extends Command {
         aliases: string[] = []

--- a/test/help/format-root.test.ts
+++ b/test/help/format-root.test.ts
@@ -7,10 +7,15 @@ import {Help} from '../../src/help'
 import {getPlatform} from '../../src/util/os'
 
 const VERSION = require('../../package.json').version
-const USER_AGENT = `@oclif/core/${VERSION} ${getPlatform()}-${process.arch} node-${process.version}`
 
 describe('formatRoot', () => {
   let config: Config
+
+  let USER_AGENT: string
+
+  before(async () => {
+    USER_AGENT = `@oclif/core/${VERSION} ${await getPlatform()}-${process.arch} node-${process.version}`
+  })
 
   beforeEach(async () => {
     config = await Config.load()


### PR DESCRIPTION
Follow-up to #1636 (fix for @W-23807278@), refactored to use dynamic imports instead of the `require` call, thereby allowing the fix to work on node v18/v20.

Closes #1637 