### PR TITLE
fix: ignore defaulted flags in dependency validation

### DIFF
--- a/src/parser/validate.ts
+++ b/src/parser/validate.ts
@@ -274,7 +274,9 @@ export async function validate(parse: {input: ParserInput; output: ParserOutput}
     const base = {name, validationFn: 'validateDependsOn'}
     const resolved = await resolveFlags(flags)
 
-    const foundAll = Object.values(resolved).every((val) => val !== undefined)
+    const foundAll = Object.entries(resolved).every(
+      ([flag, value]) => value !== undefined && !parse.output.metadata.flags?.[flag]?.setFromDefault,
+    )
     if (!foundAll) {
       const formattedFlags = Object.keys(resolved)
         .map((f) => `--${f}`)

--- a/test/parser/parse.test.ts
+++ b/test/parser/parse.test.ts
@@ -1575,6 +1575,52 @@ See more help with --help`)
 
       expect(message).to.include('All of the following must be provided when using --foo: --bar')
     })
+
+    it('fails when a dependency is set from its default', async () => {
+      let message = ''
+      try {
+        await parse(['--foo', 'a'], {
+          flags: {
+            foo: Flags.string({dependsOn: ['bar']}),
+            bar: Flags.string({default: 'b'}),
+          },
+        })
+      } catch (error: any) {
+        message = error.message
+      }
+
+      expect(message).to.include('All of the following must be provided when using --foo: --bar')
+    })
+
+    it('succeeds when a dependency explicitly matches its default', async () => {
+      const out = await parse(['--foo', 'a', '--bar', 'b'], {
+        flags: {
+          foo: Flags.string({dependsOn: ['bar']}),
+          bar: Flags.string({default: 'b'}),
+        },
+      })
+
+      expect(out.flags.foo).to.equal('a')
+      expect(out.flags.bar).to.equal('b')
+    })
+  })
+
+  describe("relationships: 'all'", () => {
+    it('fails when a dependency is set from its default', async () => {
+      let message = ''
+      try {
+        await parse(['--foo', 'a'], {
+          flags: {
+            foo: Flags.string({relationships: [{flags: ['bar'], type: 'all'}]}),
+            bar: Flags.string({default: 'b'}),
+          },
+        })
+      } catch (error: any) {
+        message = error.message
+      }
+
+      expect(message).to.include('All of the following must be provided when using --foo: --bar')
+    })
   })
 
   describe('exclusive', () => {


### PR DESCRIPTION
## Summary

- treat dependency flags populated only by defaults as not provided
- preserve dependency validation when an explicit value matches the flag default
- add regression coverage for `dependsOn` and `relationships` with type `all`

## Testing

- `yarn mocha --forbid-only test/parser/parse.test.ts test/parser/validate.test.ts`
- `yarn test`

Closes #1639